### PR TITLE
fader fix for the navigation toolbar

### DIFF
--- a/Imports/ArcGIS/Runtime/Toolkit/Controls/HomeButton.qml
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls/HomeButton.qml
@@ -30,7 +30,6 @@ StyleButton {
     tooltip: qsTr("Home")
 
     onClicked: {
-        fader.start();
         if (homeExtent)
             map.extent = homeExtent;
         else

--- a/Imports/ArcGIS/Runtime/Toolkit/Controls/NavigationToolbar.qml
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls/NavigationToolbar.qml
@@ -65,6 +65,10 @@ StyleToolbar {
                     startFader();
             }
         }
+        onClicked: {
+            if (platform !== "android" && platform !== "ios")
+                startFader();
+        }
     }
 
     //--------------------------------------------------------------------------
@@ -79,6 +83,10 @@ StyleToolbar {
                 else
                     startFader();
             }
+        }
+        onClicked: {
+            if (platform !== "android" && platform !== "ios")
+                startFader();
         }
     }
 
@@ -95,6 +103,10 @@ StyleToolbar {
                     startFader();
             }
         }
+        onClicked: {
+            if (platform !== "android" && platform !== "ios")
+                startFader();
+        }
     }
 
     //--------------------------------------------------------------------------
@@ -109,6 +121,10 @@ StyleToolbar {
                 else
                     startFader();
             }
+        }
+        onClicked: {
+            if (platform !== "android" && platform !== "ios")
+                startFader();
         }
     }
 }

--- a/Imports/ArcGIS/Runtime/Toolkit/Controls/PositionButton.qml
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls/PositionButton.qml
@@ -33,17 +33,14 @@ StyleButton {
         anchors.fill: parent
 
         onPressAndHold: {
-            fader.start();
             if (map.positionDisplay.positionSource.active)
                 map.positionDisplay.positionSource.active = false;
         }
 
         onClicked: {
-            fader.start();
-
-            if (map.positionDisplay.positionSource.active) {
+            if (map.positionDisplay.positionSource.active)
                 map.positionDisplay.mode = (map.positionDisplay.mode + 1) % positionButton.maxModes;
-            } else {
+            else {
                 map.positionDisplay.positionSource.active = true;
                 map.positionDisplay.mode = 1;
             }

--- a/Imports/ArcGIS/Runtime/Toolkit/Controls/ZoomInButton.qml
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls/ZoomInButton.qml
@@ -30,7 +30,6 @@ StyleButton {
     tooltip: qsTr("Zoom in")
 
     onClicked: {
-        fader.start();
         map.zoomToScale (map.mapScale / zoomRatio);
     }
 

--- a/Imports/ArcGIS/Runtime/Toolkit/Controls/ZoomOutButton.qml
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls/ZoomOutButton.qml
@@ -28,7 +28,6 @@ StyleButton {
     tooltip: qsTr("Zoom out")
 
     onClicked: {
-        fader.start();
         map.zoomToScale (map.mapScale * zoomRatio);
     }
 


### PR DESCRIPTION
removing fader from the button. This is called on the toolbar now instead. Calling it on the button caused the buttons to fade out at different times if they were clicked. @jtrieu please review and merge
