### PR TITLE
Awilliams/basemap widg highlight

### DIFF
--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/BasemapGalleryController.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/BasemapGalleryController.cpp
@@ -319,7 +319,6 @@ namespace Toolkit {
     m_gallery->setDisplayPropertyName("name");
     m_gallery->setDecorationPropertyName("thumbnail");
     m_gallery->setTooltipPropertyName("tooltip");
-    m_gallery->setFlagsPropertyName("flags");
   }
 
   /*!

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/BasemapGalleryItem.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/BasemapGalleryItem.cpp
@@ -116,8 +116,7 @@ BasemapGalleryItem::BasemapGalleryItem(Basemap* basemap, QImage thumbnail, QStri
   QObject(parent),
   m_thumbnail{std::move(thumbnail)},
   m_tooltip{std::move(tooltip)},
-  m_id{QUuid::createUuid()},
-  m_flags(Qt::ItemIsSelectable | Qt::ItemIsEnabled)
+  m_id{QUuid::createUuid()}
 {
   registerItem(this);
   connect(this, &BasemapGalleryItem::basemapChanged, this, &BasemapGalleryItem::thumbnailChanged);

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/BasemapGalleryItem.h
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/BasemapGalleryItem.h
@@ -80,7 +80,6 @@ namespace Toolkit {
     QImage m_thumbnail;
     QString m_tooltip;
     QUuid m_id;
-    Qt::ItemFlags m_flags;
   };
 
 } // Toolkit

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/Internal/GenericListModel.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/Internal/GenericListModel.cpp
@@ -547,19 +547,6 @@ namespace Toolkit {
     return m_elementType->property(m_tooltipPropIndex).name();
   }
 
-  void GenericListModel::setFlagsPropertyName(const QString& propertyName)
-  {
-    m_flagsPropIndex = m_elementType->indexOfProperty(propertyName.toLatin1());
-  }
-
-  QString GenericListModel::flagsPropertyName()
-  {
-    if (m_flagsPropIndex < 0)
-      return "";
-
-    return m_elementType->property(m_flagsPropIndex).name();
-  }
-
   /*!
   \brief Helper function append an additional object to this list.
   
@@ -735,6 +722,18 @@ namespace Toolkit {
       return "";
   }
 
+  /*!
+  \brief Overriden \l QAbstractListModel function. Sets the \l Qt::ItemFlags for each item in the list.
+
+  Returns flags from the \variable m_flagsCallback, which if it is not set, will use the default \l QAbstractListModel::flags will be called.
+  Flags returned are used from the \l QListView to apply visual properties.
+
+  \list
+  \li \a index Index of item
+  \endlist
+  \sa Qt::ItemFlags QFlags
+  */
+
   Qt::ItemFlags GenericListModel::flags(const QModelIndex& index) const
   {
     if (m_flagsCallback)
@@ -742,11 +741,6 @@ namespace Toolkit {
     // call default base class .flags()
     return QAbstractItemModel::flags(index);
   }
-
-  //  void GenericListModel::setFlagsCallback(std::function<FlagsCallback> f)
-  //  {
-  //    m_flagsCallback = std::move(f);
-  //  }
 
   QObject* GenericListModel::element(const QModelIndex& index)
   {
@@ -758,6 +752,15 @@ namespace Toolkit {
     return removeRows(0, count());
   }
 
+  /*!
+  \fn void Esri::ArcGISRuntime::Toolkit::GenericListModel::setFlagsCallback(Func&& f)
+  \brief Template member function used to set the callback function which calculates each item \c Qt::ItemFlags.
+
+  \list
+  \li \c Func Signature type that is accepted. Should be implicitly convertible to \variable m_flagsCallback.
+  \li \a f Function which handles the return of \c Qt::ItemFlags for each item in the collection \c QList<QObject*>
+  \endlist
+  */
   /*!
   \fn T* Esri::ArcGISRuntime::Toolkit::GenericListModel::element(const QModelIndex& index) const
   

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/Internal/GenericListModel.h
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/Internal/GenericListModel.h
@@ -56,10 +56,6 @@ public:
 
   QString tooltipPropertyName();
 
-  void setFlagsPropertyName(const QString& propertyName);
-
-  QString flagsPropertyName();
-
   int rowCount(const QModelIndex& parent = QModelIndex()) const override;
 
   QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
@@ -76,8 +72,6 @@ public:
                       int role = Qt::DisplayRole) const override;
 
   Qt::ItemFlags flags(const QModelIndex& index) const override;
-
-  //void setFlagsCallback(std::function<FlagsCallback> f);
 
   template <typename Func>
   void setFlagsCallback(Func&& f)
@@ -112,7 +106,6 @@ private:
   int m_displayPropIndex = -1;
   int m_decorationPropIndex = -1;
   int m_tooltipPropIndex = -1;
-  int m_flagsPropIndex = -1;
   const QMetaObject* m_elementType = nullptr;
   QList<QObject*> m_objects;
   std::function<FlagsCallback> m_flagsCallback;


### PR DESCRIPTION
Branch encapsulating the feature to disable the highlight of not supported basemaps.
Achieved by overriding the .flag() in GenericModel and added flags in the GalleryItem.

- Unfortunately, just setting the flags as 'notselectable | notenabled', the listview will let the click go through, so a check on the item flag currently set is needed to be done in the view part of the component.
- Not available basemaps are shown as grayed out icons, but there is still a blue background around them, not helping in hinting that they are not available. If a user clicks, nothing happens, so they should get the idea of disabled
