### PR TITLE
Awilliams/basemap widg default thumbnail

### DIFF
--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/BasemapGalleryItem.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/BasemapGalleryItem.cpp
@@ -208,7 +208,8 @@ QString BasemapGalleryItem::name() const
 
 /*!
   \brief Returns the thumbnail override of this item if valid. Otherwise
-  returns the thumbnail on the basemap's item, if available.
+  returns the thumbnail on the basemap's item, if available. Otherwise, return
+  the default thumbnail.
   \sa BasemapGalleryItem::thumbnailOverride
  */
 QImage BasemapGalleryItem::thumbnail() const


### PR DESCRIPTION
Setting default thumbnail for basemaps with no thumbnails or user overridden thumbnail
![image](https://user-images.githubusercontent.com/91129623/138112648-a9d9a818-e7ea-48a5-a2b3-022914644dc3.png)