### PR TITLE
Add alphabetical sorting to c++ & qml Basemap Gallery

### DIFF
--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/BasemapGalleryController.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/BasemapGalleryController.cpp
@@ -221,7 +221,13 @@ namespace Toolkit {
       basemapsVector.reserve(basemaps->rowCount());
       std::copy(std::cbegin(*basemaps), std::cend(*basemaps), std::back_inserter(basemapsVector));
       std::sort(std::begin(basemapsVector), std::end(basemapsVector), [](Basemap* b1,Basemap* b2){
-        return b1->item()->title() < b2->item()->title();
+        // Check validity of basemap->item() and if title() is empty. If either is true, push to end of list.
+        if (!b1->item() || b1->item()->title() == "")
+          return false;
+        else if (!b2->item() || b2->item()->title() == "")
+          return true;
+        else
+          return b1->item()->title() < b2->item()->title();
       });
 
       // For each discovered map, add it to our gallery.

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/BasemapGalleryController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/BasemapGalleryController.qml
@@ -239,8 +239,15 @@ QtObject {
 
             // Sort the basemaps in basemapVector alphabetically using the title.
             basemapsArray.sort(function(b1, b2) {
-                // localeCompare returns 1 if b1 > b2, 0 if b1 = b2, and -1 if b1 < b2.
-                return b1.item.title.localeCompare(b2.item.title)
+                // Check validity of basemap.item and if title is empty. If either is true, push to end of list.
+                if (!b1.item || b1.item.title === "")
+                    return 1;
+                else if (!b2.item || b2.item.title === "")
+                    return -1;
+                else {
+                    // localeCompare returns 1 if b1 > b2, 0 if b1 = b2, and -1 if b1 < b2.
+                    return b1.item.title.localeCompare(b2.item.title)
+                }
             });
 
             // Add each basemap to the Basemap Gallery.


### PR DESCRIPTION
Currently, the Basemap Gallery does not implement any sorting on basemaps retrieved from a portal. This has caused the verification team issues when creating automated tests. 

This PR adds alphabetical sorting - basemap's in the Basemap Gallery will now be sorted alphabetically. This sorting is applied to both the default developer basemaps and when using a portal containing custom basemaps (i.e. basemaps will always be sorted alphabetically).

Please could you review these changes @mrwillyees?