### PR TITLE
added param to func

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/OAuth2View.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/OAuth2View.qml
@@ -52,7 +52,7 @@ Dialog {
 
         url: controller.currentChallengeUrl
 
-        onLoadingChanged: {
+        onLoadingChanged: (loadRequest) => {
             if (loadRequest.status === WebView.LoadSucceededStatus) {
                 forceActiveFocus();
             } else if (loadRequest.status === WebView.LoadFailedStatus) {


### PR DESCRIPTION
in qt6 when using js functions that pass named parameters, it is needed to explicitly name them. I recall this is the chosen style when defining the handler function:
`onEvent: parameter => {
}`

The warning outputted is similar as this: `Injection of parameters into signal handlers is deprecated. Use JavaScript functions with formal parameters instead.`