### PR TITLE
new permissions API

### DIFF
--- a/augmentedreality/Common/include/Android/ArCoreWrapper.h
+++ b/augmentedreality/Common/include/Android/ArCoreWrapper.h
@@ -42,8 +42,10 @@ class ArCoreFrameRenderer;
 class ArCorePointCloudRenderer;
 class ArCorePlaneRenderer;
 
-class ArCoreWrapper
+class ArCoreWrapper : public QObject
 {
+  Q_OBJECT
+
 public:
   ArCoreWrapper(ArcGISArViewInterface* arcGISArView);
   ~ArCoreWrapper();


### PR DESCRIPTION
Need to PR this way until my devtopia account is added to the ESRI org. 

The timer is there to prevent a permanent hang in the loop.exec() due to some sort of hiccup or something. The tradeoff is that if the user returns and selects a permission after the timer has ended, the app will crash after. IMO, we should not use a timer, but I wanted to see others thoughts on this. If for some reason the loop.exec() bugs out on a forever loop, the user will just close and re-open the app. 

I believe we still need to do this synchronously because often when trying this asynch we are met with camera is null type errors, and the app must be reset to use the camera. This was observed on release.