### PR TITLE
Bri12415/ar core

### DIFF
--- a/augmentedreality/Common/include/Android/ArCoreWrapper.h
+++ b/augmentedreality/Common/include/Android/ArCoreWrapper.h
@@ -24,6 +24,8 @@
 #include <QOpenGLFunctions>
 #include <array>
 
+#include "Object.h"
+
 // forward declaration of AR core types to avoid include "arcore_c_api.h" here.
 using ArSession = struct ArSession_;
 using ArFrame = struct ArFrame_;
@@ -42,8 +44,10 @@ class ArCoreFrameRenderer;
 class ArCorePointCloudRenderer;
 class ArCorePlaneRenderer;
 
-class ArCoreWrapper
+class ArCoreWrapper : public Object
 {
+  Q_OBJECT
+
 public:
   ArCoreWrapper(ArcGISArViewInterface* arcGISArView);
   ~ArCoreWrapper();

--- a/augmentedreality/Common/include/Android/ArCoreWrapper.h
+++ b/augmentedreality/Common/include/Android/ArCoreWrapper.h
@@ -44,7 +44,7 @@ class ArCoreFrameRenderer;
 class ArCorePointCloudRenderer;
 class ArCorePlaneRenderer;
 
-class ArCoreWrapper : public Object
+class ArCoreWrapper : public QObject
 {
   Q_OBJECT
 

--- a/augmentedreality/Common/source/Android/ArCoreWrapper.cpp
+++ b/augmentedreality/Common/source/Android/ArCoreWrapper.cpp
@@ -304,7 +304,7 @@ void ArCoreWrapper::createArSession()
     loop.exec();
   }
 
-  //If the time is active we timed out
+  //If remaining time is 0 the timer ran out
   if(timeout.remainingTime() == 0)
   {
     emit m_arcGISArView->errorOccurred("ARCore failure", "Failed to access to the camera.");


### PR DESCRIPTION


I believe we still need to do this synchronously because often when trying this asynch we are met with camera is null type errors, and the app must be reset to use the camera. This was observed on release.