### PR TITLE
block until permissions

### DIFF
--- a/augmentedreality/Common/include/Android/ArCoreWrapper.h
+++ b/augmentedreality/Common/include/Android/ArCoreWrapper.h
@@ -42,9 +42,8 @@ class ArCoreFrameRenderer;
 class ArCorePointCloudRenderer;
 class ArCorePlaneRenderer;
 
-class ArCoreWrapper : public QObject
+class ArCoreWrapper
 {
-    Q_OBJECT
 
 public:
   ArCoreWrapper(ArcGISArViewInterface* arcGISArView);

--- a/augmentedreality/Common/include/Android/ArCoreWrapper.h
+++ b/augmentedreality/Common/include/Android/ArCoreWrapper.h
@@ -42,8 +42,10 @@ class ArCoreFrameRenderer;
 class ArCorePointCloudRenderer;
 class ArCorePlaneRenderer;
 
-class ArCoreWrapper
+class ArCoreWrapper : public QObject
 {
+    Q_OBJECT
+
 public:
   ArCoreWrapper(ArcGISArViewInterface* arcGISArView);
   ~ArCoreWrapper();

--- a/augmentedreality/Common/source/Android/ArCoreWrapper.cpp
+++ b/augmentedreality/Common/source/Android/ArCoreWrapper.cpp
@@ -289,7 +289,7 @@ void ArCoreWrapper::createArSession()
 
   if (qApp->checkPermission(cameraPermission) == Qt::PermissionStatus::Undetermined)
   {
-    qApp->requestPermission(cameraPermission, [&loop]() {
+    qApp->requestPermission(cameraPermission, &loop, [&loop]() {
       //Connect finishing requestPermission to quitting the blocking loop
       loop.quit();
     });

--- a/augmentedreality/Common/source/Android/ArCoreWrapper.cpp
+++ b/augmentedreality/Common/source/Android/ArCoreWrapper.cpp
@@ -289,7 +289,7 @@ void ArCoreWrapper::createArSession()
 
   if (qApp->checkPermission(cameraPermission) == Qt::PermissionStatus::Undetermined)
   {
-    qApp->requestPermission(cameraPermission, this, [this, &loop]() {
+    qApp->requestPermission(cameraPermission, [&loop]() {
       //Connect finishing requestPermission to quitting the blocking loop
       loop.quit();
     });

--- a/augmentedreality/Common/source/Android/ArCoreWrapper.cpp
+++ b/augmentedreality/Common/source/Android/ArCoreWrapper.cpp
@@ -26,12 +26,11 @@
 // Qt headers
 #include <QCoreApplication>
 #include <QGuiApplication>
+#include <QPermission>
 #include <QScreen>
 
 // C++ headers
 #include <array>
-
-#include <QtCore/private/qandroidextras_p.h>
 
 using namespace Esri::ArcGISRuntime;
 using namespace Esri::ArcGISRuntime::Toolkit::Internal;
@@ -285,20 +284,27 @@ void ArCoreWrapper::createArSession()
   if (m_arSession)
     return;
 
-  // request camera permission
-  auto checkPermissionResultFuture = QtAndroidPrivate::checkPermission(QtAndroidPrivate::PermissionType::Camera);
-  checkPermissionResultFuture.waitForFinished();
-  const auto checkPermissionResult = checkPermissionResultFuture.result();
-  if (checkPermissionResult != QtAndroidPrivate::PermissionResult::Authorized)
+  QCameraPermission cameraPermission;
+  QEventLoop loop;
+
+  if (qApp->checkPermission(cameraPermission) == Qt::PermissionStatus::Undetermined)
   {
-    auto requestPermissionResultFuture = QtAndroidPrivate::requestPermission(QtAndroidPrivate::PermissionType::Camera);
-    requestPermissionResultFuture.waitForFinished();
-    const auto requestPermissionResult = requestPermissionResultFuture.result();
-    if (requestPermissionResult != QtAndroidPrivate::PermissionResult::Authorized)
-    {
+    qApp->requestPermission(cameraPermission, this, [this, &loop]() {
+      //Connect finishing requestPermission to quitting the blocking loop
+      loop.quit();
+    });
+    //Start the blocking loop to wait for permissions
+    loop.exec();
+  }
+
+  //checkPermission will never return Undetermined after call to requestPermission
+  switch (qApp->checkPermission(cameraPermission)) {
+    case Qt::PermissionStatus::Granted:
+      break;
+    case Qt::PermissionStatus::Denied:
+    default:
       emit m_arcGISArView->errorOccurred("ARCore failure", "Failed to access to the camera.");
       return;
-    }
   }
 
   // try to create the ARCore session. This function can fail if the user reject the authorization


### PR DESCRIPTION
After researching other solutions, I believe this is the one we want to use. Ive listed a couple other ideas below and why we cant use them.

**QFuture w/ QFutureWatcher**
Can’t use QFuture, because of this error `W qt.permissions: : Permissions can only be requested from the GUI (main) thread`. The call to `Qt::Concurrent::run` spawns a new thread which is where our permission check would happen

**Semaphore w/ QFutureWatcher**
Same as above