### PR TITLE
rename modelData

### DIFF
--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/Internal/GenericListModel.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/Internal/GenericListModel.cpp
@@ -55,7 +55,7 @@ namespace Esri::ArcGISRuntime::Toolkit {
     \li Value
     \li Type
   \row
-    \li modelData
+    \li
     \li \c{Qt::UserRole}
     \li \c{Foo*}
   \row
@@ -72,7 +72,7 @@ namespace Esri::ArcGISRuntime::Toolkit {
     \li \c {bool}
  \endtable
 
- A hard-coded \e{modelData} role is always exposed as \c Qt::UserRole,
+ A hard-coded \e{listData} role is always exposed as \c Qt::UserRole,
  followed by each property on \c Foo in order of declaration.
 
  Both \c data and \c setData can be called respectively on these roles.
@@ -290,7 +290,7 @@ namespace Esri::ArcGISRuntime::Toolkit {
   \brief A collection of role names and the corresponding user role enum.
 
   This will always return the hard-coded \e{(name, role)} combination
-  \c{(modelData, Qt::UserRole)}.
+  \c{(listData, Qt::UserRole)}.
 
   For each subsequent property it will also expose:
   \c{(property_N, Qt::UserRole + N + 1)} where \tt{property_N} is the N\sup{th}
@@ -304,7 +304,7 @@ namespace Esri::ArcGISRuntime::Toolkit {
      \li Name
      \li Value
    \row
-     \li modelData
+     \li listData
      \li \c{Qt::UserRole}
    \row
      \li propertyA
@@ -326,7 +326,7 @@ namespace Esri::ArcGISRuntime::Toolkit {
       return {};
 
     QHash<int, QByteArray> output;
-    output.insert(Qt::UserRole, "modelData");
+    output.insert(Qt::UserRole, "listData");
 
     const int offset = m_elementType->propertyOffset();
     for (int i = offset; i < m_elementType->propertyCount(); ++i)

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
@@ -208,8 +208,8 @@ Pane {
             id: basemapDelegate
             width: view.cellWidth
             height: view.cellHeight
-            enabled: controller.basemapMatchesCurrentSpatialReference(modelData.basemap)
-            onClicked: controller.setCurrentBasemap(modelData.basemap)
+            enabled: controller.basemapMatchesCurrentSpatialReference(listData.basemap)
+            onClicked: controller.setCurrentBasemap(listData.basemap)
             indicator: Item { }
             down: GridView.isCurrentItem
 
@@ -229,13 +229,13 @@ Pane {
             }
             icon {
                 cache: false
-                source: modelData.thumbnailUrl
+                source: listData.thumbnailUrl
                 width: basemapGallery.internal.defaultCellSize
                 height: basemapGallery.internal.defaultCellSize
                 color: "transparent"
             }
 
-            text: modelData.name === "" ? "Unnamed basemap" : modelData.name
+            text: listData.name === "" ? "Unnamed basemap" : listData.name
             display: {
                 if (basemapGallery.internal.calculatedStyle === BasemapGallery.ViewStyle.List) {
                     return AbstractButton.TextBesideIcon;
@@ -250,23 +250,23 @@ Pane {
                     Qt.openUrlExternally(link)
                 }
             }
-            ToolTip.text: modelData.tooltip
+            ToolTip.text: listData.tooltip
             MouseArea {
                 id: mouseArea
                 z : 2
                 anchors.fill: parent
                 hoverEnabled: true
                 onClicked: {
-                    if (controller.currentBasemap !== modelData.basemap)
+                    if (controller.currentBasemap !== listData.basemap)
                         busyIndicator.running = true;
-                    controller.setCurrentBasemap(modelData.basemap);
+                    controller.setCurrentBasemap(listData.basemap);
                 }
 
                 // When mouse enters thumbnail area, use timer to delay showing of tooltip.
                 onEntered: {
                     // Create a definition for the showTooltipFn property of timerOnEntered
                     timerOnEntered.showTooltipFn = () => {
-                        if (allowTooltips && mouseArea.containsMouse && modelData.tooltip !== "")
+                        if (allowTooltips && mouseArea.containsMouse && listData.tooltip !== "")
                         basemapDelegate.ToolTip.visible = true;
                     }
                     timerOnEntered.start();

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/BookmarksView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/BookmarksView.qml
@@ -79,7 +79,7 @@ Pane {
             text: name
             width: listView.width
             indicator: null
-            onPressed: controller.zoomToBookmarkExtent(modelData)
+            onPressed: controller.zoomToBookmarkExtent(listData)
         }
     }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/ClientCertificateView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/ClientCertificateView.qml
@@ -97,7 +97,7 @@ Dialog {
             }
 
             delegate: ItemDelegate {
-                text: modelData
+                text: listData
                 anchors {
                     left: parent.left
                     right: parent.right

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/BasemapGalleryController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/BasemapGalleryController.qml
@@ -69,7 +69,7 @@ QtObject {
       \brief The gallery of BasemapGalleryItem objects.
 
       Internally, the gallery is a QML ListModel containing elements of type ListElement.
-      Each ListElement has a single property `modelData`, which maps to a BasemapGalleryItem.
+      Each ListElement has a single property `listData`, which maps to a BasemapGalleryItem.
      */
     readonly property alias gallery: internal.gallery
 
@@ -123,7 +123,7 @@ QtObject {
             return false;
         }
         internal.gallery.append(
-                    { "modelData" : internal.galleryItem.createObject(
+                    { "listData" : internal.galleryItem.createObject(
                                         this,
                                         {
                                             basemap: basemap,
@@ -149,7 +149,7 @@ QtObject {
         // We do a name and ItemID comparisons, since the ArcGIS QML API disallows
         // pointer comparisons.
         for (let i = 0; i < gallery.count; i++) {
-            let b = gallery.get(i).modelData;
+            let b = gallery.get(i).listData;
             if (b && b.basemap && b.basemap.name === basemap.name) {
                 // If there is an item involved, we can check the itemId to confirm the sameness.
                 if ((b.basemap.item && basemap.item && b.basemap.item.itemId === basemap.item.itemId)

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/BookmarksViewController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/BookmarksViewController.qml
@@ -39,15 +39,15 @@ QtObject {
       \brief The bookmarks of Bookmark list objects.
 
       Internally, the list is a QML ListModel containing elements of type ListElement.
-      Each ListElement has a `modelData` and property `name`, which maps to a Bookmark.
+      Each ListElement has a `listData` and property `name`, which maps to a Bookmark.
      */
     readonly property alias bookmarks: internal.bookmarks
 
     /*!
-       \brief Method that takes a Bookmark \a modelData and  zoom to that bookmark in the `geoView`.
+       \brief Method that takes a Bookmark \a listData and  zoom to that bookmark in the `geoView`.
      */
-    function zoomToBookmarkExtent(modelData) {
-        geoView.setBookmark(modelData);
+    function zoomToBookmarkExtent(listData) {
+        geoView.setBookmark(listData);
     }
 
     /*! \internal */
@@ -84,7 +84,7 @@ QtObject {
                 for (let i = 0; i <= internal.rawBookmarks.count; i++) {
                     let bookmark = internal.rawBookmarks.get(i);
                     if (bookmark)
-                        bookmarks.insert(i, {modelData: bookmark, name: bookmark.name});
+                        bookmarks.insert(i, {listData: bookmark, name: bookmark.name});
                 }
             }
         }
@@ -97,7 +97,7 @@ QtObject {
             function onRowsInserted(parent, first, last) {
                 for (let i = first; i <= last; i++) {
                     let bookmark = internal.rawBookmarks.get(i);
-                    bookmarks.insert(i, {modelData: bookmark, name: bookmark.name});
+                    bookmarks.insert(i, {listData: bookmark, name: bookmark.name});
                 }
             }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/SearchViewController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/SearchViewController.qml
@@ -131,7 +131,7 @@ QtObject {
       \qmlproperty ListModel sources
       \brief The collection of search sources to be used.
 
-      Each element is a ListElement with a single \c modelData
+      Each element is a ListElement with a single \c listData
       field, which contains the search source object.
      */
     readonly property alias sources: internal.sources
@@ -246,7 +246,7 @@ QtObject {
         // Go through all sources and start a search.
         const area = restrictToArea ? internal.queryArea : null;
         for (let i = 0; i < internal.sources.count; i++) {
-            const source = internal.sources.get(i).modelData;
+            const source = internal.sources.get(i).listData;
             if (source) {
                 source.search(controller.currentQuery, area);
             }
@@ -298,7 +298,7 @@ QtObject {
         property ListModel sources: ListModel {
             onRowsInserted: (parent, first, last) =>{
                 for (let i = first; i <= last; ++i) {
-                    const source = sources.get(i).modelData;
+                    const source = sources.get(i).listData;
                     if (source) {
                         // Listen to the source changes in results/suggestions.
                         source.suggestions.suggestionsAdded.connect(internal.onSuggestionsAdded);
@@ -309,7 +309,7 @@ QtObject {
             }
             onRowsAboutToBeRemoved: {
                 for (let i = first; i <= last; i++) {
-                    const source = source.get(i).modelData;
+                    const source = source.get(i).listData;
                     if (source) {
                         // Disconnect from source.
                         source.suggestions.suggestionsAdded.disconnect(internal.onSuggestionsAdded);
@@ -450,7 +450,7 @@ QtObject {
 
         onQueryCenterChanged: {
             for (let i = 0; i < internal.sources.count; i++) {
-                const source = internal.sources.get(i).modelData;
+                const source = internal.sources.get(i).listData;
                 if (source) {
                     // Update all sources with changes to queryCenter.
                     source.preferredSearchLocation = internal.queryCenter;
@@ -468,7 +468,7 @@ QtObject {
             internal.graphicsOverlay = null;
             internal.sources.clear();
             internal.sources.append({
-                                        "modelData" : internal.defaultWorldGeocoderSource.createObject(this)
+                                        "listData" : internal.defaultWorldGeocoderSource.createObject(this)
                                     });
 
             if (controller.geoView) {
@@ -482,7 +482,7 @@ QtObject {
     onCurrentQueryChanged: {
         controller.eligableForRequery = false;
         for (let i = 0; i < internal.sources.count; i++) {
-            const source = internal.sources.get(i).modelData;
+            const source = internal.sources.get(i).listData;
             if (source) {
                 source.suggestions.searchText = controller.currentQuery;
             }

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/CoordinateConversion.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/CoordinateConversion.qml
@@ -118,11 +118,11 @@ Pane {
                 onCurrentIndexChanged: {
                     const index = currentIndex;
                     const formats = coordinateConversionWindow.controller.formats;
-                    let modelData = formats[index];
-                    if (modelData === undefined) {
-                        modelData = formats.element(formats.index(index, 0));
+                    let listData = formats[index];
+                    if (listData === undefined) {
+                        listData = formats.element(formats.index(index, 0));
                     }
-                    inputFormat.type = modelData;
+                    inputFormat.type = listData;
                     inputFormat.updateCoordinatePoint(coordinateConversionWindow.controller.currentPoint());
                 }
             }
@@ -176,7 +176,7 @@ Pane {
                             text: name
                             enabled: text !== inputModeButton.text
                             onTriggered: {
-                                coordinateConversionWindow.controller.addNewCoordinateResultForOption(modelData);
+                                coordinateConversionWindow.controller.addNewCoordinateResultForOption(listData);
                             }
                         }
                     }
@@ -285,11 +285,11 @@ Pane {
                         MenuItem {
                             text: "Copy to clipboard"
                             // Copy not available in pure QML API
-                            enabled: modelData.copyNotationToClipboard !== undefined
+                            enabled: listData.copyNotationToClipboard !== undefined
                             visible: enabled
                             height: enabled ? implicitHeight : 0
                             onClicked: {
-                                modelData.copyNotationToClipboard();
+                                listData.copyNotationToClipboard();
                             }
                         }
                     }


### PR DESCRIPTION
Change the naming convention inside of `GenericListModel` to avoid shadowing Qt's `modelData`.

(Writeup is WIP)