### PR TITLE
modelData not listModelData

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/ClientCertificateView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/ClientCertificateView.qml
@@ -97,7 +97,7 @@ Dialog {
             }
 
             delegate: ItemDelegate {
-                text: listModelData
+                text: modelData
                 anchors {
                     left: parent.left
                     right: parent.right


### PR DESCRIPTION
This was mistakenly done by me from https://github.com/Esri/arcgis-maps-sdk-toolkit-qt/pull/605. I had thought that the data structure being referred to by `controller.clientCertificateInfos` was one of our ListModels, but it is not. It is just a QStringList, so we can use the `modelData` keyword.

**Before:**
![image](https://github.com/Esri/arcgis-maps-sdk-toolkit-qt/assets/105450339/5fbcb568-4467-47e9-bfdb-378a896c35bf)


**After:**
![image](https://github.com/Esri/arcgis-maps-sdk-toolkit-qt/assets/105450339/625413c7-dad3-477d-b249-729be9d753d6)


Thanks @ldanzinger for pointing this out.