### PR TITLE
Add CMake files as alternatives to qmake files in uitools/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 200.4
+* Added CMake files for installing ArcGIS Toolkit in projects that use CMake
+
 ## 200.0
 * (UtilityNetworkTrace) Introduction of the new Utility Network Trace tool (C++/Quick).
 * Increased minimum version to use Qt 6

--- a/uitools/README.md
+++ b/uitools/README.md
@@ -113,15 +113,20 @@ get added to QtCreator when you install the ArcGIS Runime SDK for Qt.
 
 - In QtCreator choose `File/New file or project/ArcGIS/ArcGIS Maps 200.4.0 Qt Quick C++ App`
 - choose settings to match the platform etc. you are building for
-- in the `.pro` file of your new app, add a line to add the library for your QML
-  plugin - for example:
+- Depending on which build tool you are using, add one of the following lines to your build file to install the Toolkit library:
+    - **QMAKE**: In the `.pro` file of your new app, add the following:
+      ```qmake
+      include(path/to/toolkitcpp.pri)
+      ```
 
-```qmake
-include(path/to/toolkitcpp.pri)
-```
-
-- in the Run environment settings for the app, add a new environment variable to
-  import the QML module - e.g:
+    - **CMAKE**: In the `CMakeLists.txt` file of your new app, add the following:
+      ```CMake
+      include(path/to/toolkitcpp_CMakeLists.txt)
+      ```
+      Don't forget to add the library in a `target_link_libraries()` statement, too:
+      ```
+      target_link_libraries(myProject PRIVATE ArcGISToolkit_Cpp)
+      ```
 
 - in `main.cpp` add a line to import the toolkit registration function.
 
@@ -174,12 +179,20 @@ get added to QtCreator when you install the ArcGIS Maps SDK for Qt.
 
 - In QtCreator choose `File/New file or project/ArcGIS/ArcGIS Maps 200.4.0 Qt Widgets App`
 - choose settings to match the platform etc. you are building for
-- in the `.pro` file of your new app, add a line to add the library for your QML
-  plugin - for example:
+- Depending on which build tool you are using, add one of the following lines to your build file to install the Toolkit library:
+    - **QMAKE**: In the `.pro` file of your new app, add the following:
+      ```qmake
+      include(path/to/toolkitwidgets.pri)
+      ```
 
-```qmake
-include(path/to/toolkitwidgets.pri)
-```
+    - **CMAKE**: In the `CMakeLists.txt` file of your new app, add the following:
+      ```CMake
+      include(path/to/toolkitwidgets_CMakeLists.txt)
+      ```
+      Don't forget to add the library in a `target_link_libraries()` statement, too:
+      ```
+      target_link_libraries(myProject PRIVATE ArcGISToolkit_Widgets)
+      ```
 
 #### Using a tool from the toolkit (toolkitwidgets.pri)
 

--- a/uitools/common_CMakeLists.txt
+++ b/uitools/common_CMakeLists.txt
@@ -1,0 +1,98 @@
+#[[ Copyright 2012-2024 Esri
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#]]
+
+#[[ QMAKE: CPPPATH = $$PWD/cpp/Esri/ArcGISRuntime/Toolkit]]
+set(CPPPATH ${CMAKE_CURRENT_LIST_DIR}/cpp/Esri/ArcGISRuntime/Toolkit)
+
+#[[ QMAKE: INCLUDEPATH += $$PWD/cpp $$CPPPATH]]
+include_directories(${CMAKE_CURRENT_LIST_DIR}/cpp ${CPPPATH})
+
+#[[ QMAKE: HEADERS += <all the header files>]]
+set(HEADERS ${CPPPATH}/AuthenticationController.h
+    ${CPPPATH}/BasemapGalleryController.h
+    ${CPPPATH}/BasemapGalleryItem.h
+    ${CPPPATH}/BookmarksViewController.h
+    ${CPPPATH}/BookmarkListItem.h
+    ${CPPPATH}/CoordinateConversionConstants.h
+    ${CPPPATH}/CoordinateConversionController.h
+    ${CPPPATH}/CoordinateConversionOption.h
+    ${CPPPATH}/CoordinateConversionResult.h
+    ${CPPPATH}/CoordinateOptionDefaults.h
+    ${CPPPATH}/FloorFilterController.h
+    ${CPPPATH}/FloorFilterFacilityItem.h
+    ${CPPPATH}/FloorFilterLevelItem.h
+    ${CPPPATH}/FloorFilterSiteItem.h
+    ${CPPPATH}/LocatorSearchSource.h
+    ${CPPPATH}/Internal/BasemapGalleryImageProvider.h
+    ${CPPPATH}/Internal/DisconnectOnSignal.h
+    ${CPPPATH}/Internal/DoOnLoad.h
+    ${CPPPATH}/Internal/GenericListModel.h
+    ${CPPPATH}/Internal/GenericTableProxyModel.h
+    ${CPPPATH}/Internal/GeoViews.h
+    ${CPPPATH}/Internal/MetaElement.h
+    ${CPPPATH}/Internal/SingleShotConnection.h
+    ${CPPPATH}/NorthArrowController.h
+    ${CPPPATH}/OverviewMapController.h
+    ${CPPPATH}/PopupViewController.h
+    ${CPPPATH}/ScalebarController.h
+    ${CPPPATH}/SearchResult.h
+    ${CPPPATH}/SearchSourceInterface.h
+    ${CPPPATH}/SearchSuggestion.h
+    ${CPPPATH}/SearchViewController.h
+    ${CPPPATH}/SmartLocatorSearchSource.h
+    ${CPPPATH}/TimeSliderController.h
+    ${CPPPATH}/UtilityNetworkFunctionTraceResult.h
+    ${CPPPATH}/UtilityNetworkFunctionTraceResultsModel.h
+    ${CPPPATH}/UtilityNetworkListItem.h
+    ${CPPPATH}/UtilityNetworkTraceController.h
+    ${CPPPATH}/UtilityNetworkTraceStartingPoint.h
+    ${CPPPATH}/UtilityNetworkTraceStartingPointsModel.h)
+
+#[[ QMAKE: SOURCES += <all the cpp files>]]
+set(SOURCES ${CPPPATH}/AuthenticationController.cpp
+    ${CPPPATH}/BasemapGalleryController.cpp
+    ${CPPPATH}/BasemapGalleryItem.cpp
+    ${CPPPATH}/BookmarksViewController.cpp
+    ${CPPPATH}/BookmarkListItem.cpp
+    ${CPPPATH}/CoordinateConversionConstants.cpp
+    ${CPPPATH}/CoordinateConversionController.cpp
+    ${CPPPATH}/CoordinateConversionOption.cpp
+    ${CPPPATH}/CoordinateConversionResult.cpp
+    ${CPPPATH}/CoordinateOptionDefaults.cpp
+    ${CPPPATH}/FloorFilterController.cpp
+    ${CPPPATH}/FloorFilterFacilityItem.cpp
+    ${CPPPATH}/FloorFilterLevelItem.cpp
+    ${CPPPATH}/FloorFilterSiteItem.cpp
+    ${CPPPATH}/LocatorSearchSource.cpp
+    ${CPPPATH}/Internal/BasemapGalleryImageProvider.cpp
+    ${CPPPATH}/Internal/GenericListModel.cpp
+    ${CPPPATH}/Internal/GenericTableProxyModel.cpp
+    ${CPPPATH}/Internal/MetaElement.cpp
+    ${CPPPATH}/NorthArrowController.cpp
+    ${CPPPATH}/OverviewMapController.cpp
+    ${CPPPATH}/PopupViewController.cpp
+    ${CPPPATH}/ScalebarController.cpp
+    ${CPPPATH}/SearchResult.cpp
+    ${CPPPATH}/SearchSourceInterface.cpp
+    ${CPPPATH}/SearchSuggestion.cpp
+    ${CPPPATH}/SearchViewController.cpp
+    ${CPPPATH}/SmartLocatorSearchSource.cpp
+    ${CPPPATH}/TimeSliderController.cpp
+    ${CPPPATH}/UtilityNetworkFunctionTraceResult.cpp
+    ${CPPPATH}/UtilityNetworkFunctionTraceResultsModel.cpp
+    ${CPPPATH}/UtilityNetworkListItem.cpp
+    ${CPPPATH}/UtilityNetworkTraceController.cpp
+    ${CPPPATH}/UtilityNetworkTraceStartingPoint.cpp
+    ${CPPPATH}/UtilityNetworkTraceStartingPointsModel.cpp)

--- a/uitools/toolkitcpp_CMakeLists.txt
+++ b/uitools/toolkitcpp_CMakeLists.txt
@@ -58,4 +58,4 @@ target_link_libraries(ArcGISToolkit PRIVATE
     Qt6::QuickControls2
     Qt6::WebView
     Qt6::Svg
-    ArcGISRuntime::Cpp)  #(This should be installed in the CMakeLists.txt that calls this one)
+    ArcGISRuntime::Cpp) #(This package should be found in the CMakeLists.txt that calls this one)

--- a/uitools/toolkitcpp_CMakeLists.txt
+++ b/uitools/toolkitcpp_CMakeLists.txt
@@ -14,7 +14,7 @@
 #]]
 
 #[[ QMAKE: include($$PWD/common.pri)]]
-include(common_CMakeLists.txt)
+include(${CMAKE_CURRENT_LIST_DIR}/common_CMakeLists.txt)
 
 #[[ QMAKE: QT += quickcontrols2 webview svg]]
 find_package(Qt6 COMPONENTS QuickControls2 WebView Svg)

--- a/uitools/toolkitcpp_CMakeLists.txt
+++ b/uitools/toolkitcpp_CMakeLists.txt
@@ -1,0 +1,61 @@
+#[[ Copyright 2012-2024 Esri
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#]]
+
+#[[ QMAKE: include($$PWD/common.pri)]]
+include(common_CMakeLists.txt)
+
+#[[ QMAKE: QT += quickcontrols2 webview svg]]
+find_package(Qt6 COMPONENTS QuickControls2 WebView Svg)
+
+#[[ QMAKE: REGISTERPATH = $$PWD/register/Esri/ArcGISRuntime/Toolkit]]
+set(REGISTERPATH ${CMAKE_CURRENT_LIST_DIR}/register/Esri/ArcGISRuntime/Toolkit)
+
+#[[ QMAKE: INCLUDEPATH += $$PWD/register $$REGISTERPATH]]
+include_directories(${CMAKE_CURRENT_LIST_DIR}/register ${REGISTERPATH})
+
+#[[ QMAKE: HEADERS += $$REGISTERPATH/register.h \
+           $$REGISTERPATH/internal/register_cpp.h]]
+list(APPEND HEADERS ${REGISTERPATH}/register.h
+    ${REGISTERPATH}/internal/register_cpp.h)
+
+#[[ QMAKE: SOURCES += $$REGISTERPATH/register.cpp \
+           $$REGISTERPATH/internal/register_cpp.cpp]]
+list(APPEND HEADERS ${REGISTERPATH}/register.cpp
+    ${REGISTERPATH}/internal/register_cpp.cpp)
+
+#[[ QMAKE: RESOURCES += \
+  $$PWD/images/esri_arcgisruntime_toolkit_images.qrc \
+  $$PWD/import/Esri/ArcGISRuntime/Toolkit/esri_arcgisruntime_toolkit_view.qrc]]
+set (RESOURCE_FILES
+    ${CMAKE_CURRENT_LIST_DIR}/images/esri_arcgisruntime_toolkit_images.qrc
+    ${CMAKE_CURRENT_LIST_DIR}/import/Esri/ArcGISRuntime/Toolkit/esri_arcgisruntime_toolkit_view.qrc
+)
+
+#[[ QMAKE: QML_IMPORT_PATH += $$PWD/import]]
+set(QML_IMPORT_PATH ${CMAKE_CURRENT_LIST_DIR}/import CACHE STRING "" FORCE)
+
+#[[ QMAKE: DEFINES += CPP_ARCGISRUNTIME_TOOLKIT]]
+add_definitions(-DCPP_ARCGISRUNTIME_TOOLKIT)
+
+# Expose the QML directory's path so that it can be added to the import path in src/main.cpp
+add_definitions(-DArcGISRuntime_Toolkit_Qml_DIR="${CMAKE_CURRENT_LIST_DIR}/import")
+
+# These commands are run implicitly as part of the qmake commands above
+qt_add_library(ArcGISToolkit STATIC ${HEADERS} ${SOURCES} ${RESOURCE_FILES})
+target_link_libraries(ArcGISToolkit PRIVATE
+    Qt6::QuickControls2
+    Qt6::WebView
+    Qt6::Svg
+    ArcGISRuntime::Cpp)  #(This should be installed in the CMakeLists.txt that calls this one)

--- a/uitools/toolkitwidgets_CMakeLists.txt
+++ b/uitools/toolkitwidgets_CMakeLists.txt
@@ -14,7 +14,7 @@
 #]]
 
 #[[ QMAKE: include($$PWD/common.pri)]]
-include(common_CMakeLists.txt)
+include(${CMAKE_CURRENT_LIST_DIR}/common_CMakeLists.txt)
 
 #[[ QMAKE: QT += widgets webenginewidgets svg]]
 find_package(Qt6 COMPONENTS Widgets WebEngineWidgets Svg)

--- a/uitools/toolkitwidgets_CMakeLists.txt
+++ b/uitools/toolkitwidgets_CMakeLists.txt
@@ -1,0 +1,85 @@
+#[[ Copyright 2012-2024 Esri
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#]]
+
+#[[ QMAKE: include($$PWD/common.pri)]]
+include(common_CMakeLists.txt)
+
+#[[ QMAKE: QT += widgets webenginewidgets svg]]
+find_package(Qt6 COMPONENTS Widgets WebEngineWidgets Svg)
+
+#[[ QMAKE: RESOURCES += $$PWD/images/esri_arcgisruntime_toolkit_images.qrc]]
+list(APPEND RESOURCES ${CMAKE_CURRENT_LIST_DIR}/images/esri_arcgisruntime_toolkit_images.qrc)
+
+#[[ QMAKE: DEFINES += WIDGETS_ARCGISRUNTIME_TOOLKIT]]
+add_definitions(-DWIDGETS_ARCGISRUNTIME_TOOLKIT)
+
+#[[ QMAKE: WIDGETPATH = $$PWD/widgets/Esri/ArcGISRuntime/Toolkit]]
+set(WIDGETPATH ${CMAKE_CURRENT_LIST_DIR}/widgets/Esri/ArcGISRuntime/Toolkit)
+
+#[[ QMAKE: INCLUDEPATH += $$PWD/widgets $$WIDGETPATH]]
+include_directories(${CMAKE_CURRENT_LIST_DIR}/widgets ${WIDGETPATH})
+
+#[[ QMAKE: HEADERS += <all the header files>]]
+list(APPEND HEADERS ${WIDGETPATH}/AuthenticationView.h
+    ${WIDGETPATH}/BasemapGallery.h
+    ${WIDGETPATH}/BookmarksView.h
+    ${WIDGETPATH}/CoordinateConversion.h
+    ${WIDGETPATH}/FloorFilter.h
+    ${WIDGETPATH}/NorthArrow.h
+    ${WIDGETPATH}/OverviewMap.h
+    ${WIDGETPATH}/Internal/ClientCertificatePasswordDialog.h
+    ${WIDGETPATH}/Internal/ClientCertificateView.h
+    ${WIDGETPATH}/Internal/CoordinateEditDelegate.h
+    ${WIDGETPATH}/Internal/Flash.h
+    ${WIDGETPATH}/Internal/OAuth2View.h
+    ${WIDGETPATH}/Internal/SslHandshakeView.h
+    ${WIDGETPATH}/Internal/UserCredentialView.h)
+
+#[[ QMAKE: SOURCES += <all the cpp files>]]
+list(APPEND SOURCES ${WIDGETPATH}/AuthenticationView.cpp
+    ${WIDGETPATH}/BasemapGallery.cpp
+    ${WIDGETPATH}/BookmarksView.cpp
+    ${WIDGETPATH}/CoordinateConversion.cpp
+    ${WIDGETPATH}/FloorFilter.cpp
+    ${WIDGETPATH}/NorthArrow.cpp
+    ${WIDGETPATH}/OverviewMap.cpp
+    ${WIDGETPATH}/Internal/ClientCertificatePasswordDialog.cpp
+    ${WIDGETPATH}/Internal/ClientCertificateView.cpp
+    ${WIDGETPATH}/Internal/CoordinateEditDelegate.cpp
+    ${WIDGETPATH}/Internal/Flash.cpp
+    ${WIDGETPATH}/Internal/OAuth2View.cpp
+    ${WIDGETPATH}/Internal/SslHandshakeView.cpp
+    ${WIDGETPATH}/Internal/UserCredentialView.cpp)
+
+#[[ QMAKE: FORMS += <all the ui files>]]
+list(APPEND FORMS ${WIDGETPATH}/AuthenticationView.ui
+    ${WIDGETPATH}/BasemapGallery.ui
+    ${WIDGETPATH}/BookmarksView.ui
+    ${WIDGETPATH}/CoordinateConversion.ui
+    ${WIDGETPATH}/FloorFilter.ui
+    ${WIDGETPATH}/OverviewMap.ui
+    ${WIDGETPATH}/Internal/ClientCertificatePasswordDialog.ui
+    ${WIDGETPATH}/Internal/ClientCertificateView.ui
+    ${WIDGETPATH}/Internal/OAuth2View.ui
+    ${WIDGETPATH}/Internal/SslHandshakeView.ui
+    ${WIDGETPATH}/Internal/UserCredentialView.ui)
+
+# These commands are run implicitly as part of the qmake commands above
+qt_add_library(ArcGISToolkit_Widgets STATIC ${HEADERS} ${SOURCES} ${RESOURCE_FILES})
+target_link_libraries(ArcGISToolkit_Widgets PRIVATE
+    Qt6::Widgets
+    Qt6::WebEngineWidgets
+    Qt6::Svg
+    ArcGISRuntime::Cpp) #(This should be installed in the CMakeLists.txt that calls this one)

--- a/uitools/toolkitwidgets_CMakeLists.txt
+++ b/uitools/toolkitwidgets_CMakeLists.txt
@@ -82,4 +82,4 @@ target_link_libraries(ArcGISToolkit_Widgets PRIVATE
     Qt6::Widgets
     Qt6::WebEngineWidgets
     Qt6::Svg
-    ArcGISRuntime::Cpp) #(This should be installed in the CMakeLists.txt that calls this one)
+    ArcGISRuntime::Cpp) #(This package should be found in the CMakeLists.txt that calls this one)


### PR DESCRIPTION
Addressing these posts:
- [Can't Install Toolkit in a CMake Project](https://community.esri.com/t5/qt-maps-sdk-questions/can-t-install-toolkit-in-a-cmake-project/m-p/1401031#M5187)
- https://github.com/Esri/arcgis-maps-sdk-toolkit-qt/issues/602

I translated toolkitcpp.pri, toolkitwidgets.pri, and common.pri into CMake files so that they can be used with CMake projects. (I didn't bother with toolkitqml.pri, since ArcGIS will not be supporting the QML API much longer.) I also updated the README to include instructions on how to use these files.

@ldanzinger , can you please review or assign a reviewer? Thanks in advance!