### PR TITLE
Fix Info.plist for iOS deployment

### DIFF
--- a/uitools/examples/iOS/Info.plist
+++ b/uitools/examples/iOS/Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
     <key>CFBundleDisplayName</key>
-    <string>cpp_quick</string>
+    <string>UitoolsExamples</string>
     <key>CFBundleExecutable</key>
-    <string>cpp_quick</string>
+    <string>UitoolsExamples</string>
     <key>CFBundleGetInfoString</key>
     <string>ArcGIS</string>
     <key>CFBundleIcons</key>


### PR DESCRIPTION
The CFBundleExecutable and CFBundleDisplayName key values in `Info.plist` didn't match the application name causing iOS deployment to fail. 