### PR TITLE
Rewording the readme to no longer mention the removed qml_quick app.

### DIFF
--- a/uitools/examples/README.md
+++ b/uitools/examples/README.md
@@ -1,10 +1,9 @@
 # UI Tools Examples
 
-This module contains two example apps, [cpp_quick](cpp_quick/cpp_quick.pro) and 
-[qml_quick](qml_quick/qml_quick.pro).
+This module contains the example app, [cpp_quick](cpp_quick/cpp_quick.pro).
 
-Both modules cover the the same functionality, demonstrating how to integrate toolkit 
-tools into a C++/Quick and QML/Quick app respectively.
+This module demonstrates how to integrate toolkit 
+tools into a C++/Quick app.
 
 ## Access token setup
 

--- a/uitools/examples/README.md
+++ b/uitools/examples/README.md
@@ -1,6 +1,6 @@
 # UI Tools Examples
 
-This module contains the example app, [cpp_quick](cpp_quick/cpp_quick.pro).
+This module contains the example app, [UitoolsExample](UitoolsExamples.pro).
 
 This module demonstrates how to integrate toolkit 
 tools into a C++/Quick app.


### PR DESCRIPTION
Stumbled across this, did a quick search and this was the only remaining mention of `qml_quick` that popped up.