### PR TITLE
use `modelData` keyword for QStringList model

### DIFF
--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/ClientCertificateView.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/ClientCertificateView.qml
@@ -97,7 +97,7 @@ Dialog {
             }
 
             delegate: ItemDelegate {
-                text: listModelData
+                text: modelData
                 anchors {
                     left: parent.left
                     right: parent.right


### PR DESCRIPTION
The `model` attached to the `ListView` for this `ItemDelegate` is a `QStringList`.

`listModelData` is a keyword exposed by our abstract list models. This should be `modelData` which is what Qt exposes.

I had fixed a similar case to this earlier:
https://github.com/Esri/arcgis-maps-sdk-toolkit-qt/pull/610
and thought I had found them all, but it looks like I missed this one. Apologies for that.

I have thoroughly double checked all usage of `modelData` and `listModelData` in the toolkit.