### PR TITLE
PopupElements toolkit components marked internal

### DIFF
--- a/uitools/common/src/FieldsPopupElementViewController.cpp
+++ b/uitools/common/src/FieldsPopupElementViewController.cpp
@@ -23,44 +23,22 @@
 namespace Esri::ArcGISRuntime::Toolkit {
 
 /*!
-  \class Esri::ArcGISRuntime::Toolkit::FieldsPopupElementViewController
-  \inmodule ArcGISRuntimeToolkit
-  \ingroup ArcGISQtToolkitUiCppControllers
-  \brief In MVC architecture, this is the controller for the corresponding
-  \c FieldsPopupElementView.
+  \internal
+  This class is an internal implementation detail and is subject to change.
  */
-
-/*!
-  \brief Constructor
-  \list
-    \li \a fieldsPopupElement - The \l {Esri::ArcGISRuntime::FieldsPopupElement} {FieldsPopupElement} used to populate the view.
-    \li \a parent - The optional parent QObject.
-  \endlist
-  */
 FieldsPopupElementViewController::FieldsPopupElementViewController(
     FieldsPopupElement* fieldsPopupElement, QObject* parent)
   : PopupElementViewItem{fieldsPopupElement, parent}
 {
 }
 
-/*!
-  \brief Destructor.
-  */
 FieldsPopupElementViewController::~FieldsPopupElementViewController() = default;
 
-/*!
-  \brief Returns the title of the \c FieldsPopupElement.
- */
 QString FieldsPopupElementViewController::title() const
 {
   return static_cast<FieldsPopupElement*>(popupElement())->title();
 }
 
-/*!
-  \brief Returns the combination of each element from \l {Esri::ArcGISRuntime::FieldsPopupElement::labels} {labels} and
-  \l {Esri::ArcGISRuntime::FieldsPopupElement::formattedValues} {formattedValues} of the
-  \c FieldsPopupElement in a QList of QMap elements
-  */
 QVariantList FieldsPopupElementViewController::labelsAndValues() const
 {
   const auto list1 = static_cast<FieldsPopupElement*>(popupElement())->labels();
@@ -82,16 +60,3 @@ QVariantList FieldsPopupElementViewController::labelsAndValues() const
 }
 
 } // namespace Esri::ArcGISRuntime::Toolkit
-
-/*!
-  \fn void Esri::ArcGISRuntime::Toolkit::FieldsPopupElementViewController::fieldsPopupElementChanged()
-  \brief Signal emitted when the underlying \c FieldsPopupElement changes.
- */
-
-/*!
-  \property Esri::ArcGISRuntime::Toolkit::FieldsPopupElementViewController::title
- */
-
-/*!
-  \property Esri::ArcGISRuntime::Toolkit::FieldsPopupElementViewController::values
- */

--- a/uitools/common/src/PopupElementViewItem.cpp
+++ b/uitools/common/src/PopupElementViewItem.cpp
@@ -18,63 +18,32 @@
 namespace Esri::ArcGISRuntime::Toolkit {
 
 /*!
-  \class Esri::ArcGISRuntime::Toolkit::PopupElementViewItem
-  \inmodule ArcGISRuntimeToolkit
-  \brief This is the base class for a number of different PopupElementViewControllers, such as \l
-    {Esri::ArcGISRuntime::Toolkit::TextPopupElementViewController} {TextPopupElementViewController}, and \l
-    {Esri::ArcGISRuntime::Toolkit::FieldsPopupElementViewController} {FieldsPopupElementViewController}, and \l
-    {Esri::ArcGISRuntime::Toolkit::AttachmentsPopupElementViewController} {AttachmentsPopupElementViewController}, and \l
-    {Esri::ArcGISRuntime::Toolkit::MediaPopupElementViewController} {MediaPopupElementViewController}.
-
-    It contains a \c PopupElement and provides access to it's \c PopupElementType. This is used to build a
-    GenericListModel to be provided to PopupView which can access the individual PopupElementViewControllers and
-    pass them along to the correct QML view.
+  \internal
+  This class is an internal implementation detail and is subject to change.
  */
-
-/*!
- \brief Constructor
- \list
-   \li \a parent Parent owning \c QObject.
- \endlist
-  */
 PopupElementViewItem::PopupElementViewItem(QObject *parent)
   : QObject{parent}
 {
 }
 
-/*!
-\brief Constructor. Takes a \a popupElement and \a parent object.
-  */
 PopupElementViewItem::PopupElementViewItem(PopupElement* popupElement, QObject* parent)
   : QObject{parent}
   , m_popupElement{std::move(popupElement)}
 {
 }
 
-/*!
-  \brief Destructor.
-*/
 PopupElementViewItem::~PopupElementViewItem() = default;
 
-/*!
- \brief Returns the c/ PopupElementType of the c/ PopupElement.
- */
 QmlEnums::PopupElementType PopupElementViewItem::popupElementType() const
 {
   return static_cast<QmlEnums::PopupElementType>(m_popupElement->popupElementType());
 }
 
-/*!
-  \brief Returns the \c PopupElement.
-*/
 PopupElement* PopupElementViewItem::popupElement() const
 {
   return m_popupElement ? m_popupElement : nullptr;
 }
 
-/*!
-  \brief Sets the \a popupElement.
- */
 void PopupElementViewItem::setPopupElement(PopupElement* popupElement)
 {
   if (m_popupElement == popupElement)
@@ -95,12 +64,3 @@ void PopupElementViewItem::setPopupElement(PopupElement* popupElement)
 }
 
 } // namespace Esri::ArcGISRuntime::Toolkit
-
-/*!
-  \fn void Esri::ArcGISRuntime::Toolkit::PopupElementViewItem::popupElementChanged()
-  \brief Signal emitted when the \c PopupElement changes.
- */
-
-/*!
-  \property Esri::ArcGISRuntime::Toolkit::PopupElementViewItem::popupElementType
- */

--- a/uitools/common/src/TextPopupElementViewController.cpp
+++ b/uitools/common/src/TextPopupElementViewController.cpp
@@ -22,19 +22,8 @@
 namespace Esri::ArcGISRuntime::Toolkit {
 
 /*!
-  \class Esri::ArcGISRuntime::Toolkit::TextPopupElementViewController
-  \inmodule ArcGISRuntimeToolkit
-  \ingroup ArcGISQtToolkitUiCppControllers
-  \brief In MVC architecture, this is the controller for the corresponding
-  \c TextPopupElementView.
- */
-
-/*!
-  \brief Constructor
-  \list
-    \li \a textPopupElement - The \l {Esri::ArcGISRuntime::TextPopupElement} {TextPopupElement} used to populate the view.
-    \li \a parent - The optional parent QObject.
-  \endlist
+  \internal
+  This class is an internal implementation detail and is subject to change.
  */
 TextPopupElementViewController::TextPopupElementViewController(
     TextPopupElement* textPopupElement, QObject* parent)
@@ -42,26 +31,11 @@ TextPopupElementViewController::TextPopupElementViewController(
 {
 }
 
-/*!
-  \brief Destructor.
-  */
 TextPopupElementViewController::~TextPopupElementViewController() = default;
 
-/*!
-  \brief Returns the text of the \c TextPopupElement.
-  */
 QString TextPopupElementViewController::text() const
 {
   return popupElement() ? static_cast<TextPopupElement*>(popupElement())->text() : nullptr;
 }
 
 } // namespace Esri::ArcGISRuntime::Toolkit
-
-/*!
-  \fn void Esri::ArcGISRuntime::Toolkit::TextPopupElementViewController::textPopupElementChanged()
-  \brief Signal emitted when the \c text changes.
- */
-
-/*!
-  \property Esri::ArcGISRuntime::Toolkit::TextPopupElementViewController::text
- */

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/FieldsPopupElementView.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/FieldsPopupElementView.qml
@@ -24,10 +24,8 @@ ListView {
     id: fieldsPopupElementView
 
     /*!
-      \qmlproperty FieldsPopupElementView controller
-      \brief The Controller handles reading from the FieldsPopupElement.
-
-      \sa Esri::ArcGISRuntime::Toolkit::FieldsPopupElementViewController
+      \internal
+    This class is an internal implementation detail and is subject to change.
     */
     property var controller: null
 

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/TextPopupElementView.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/TextPopupElementView.qml
@@ -23,9 +23,8 @@ Item {
     id: textPopupElementView
 
     /*!
-      \qmlproperty TextPopupElementView controller
-      \brief The Controller handles reading from the TextPopupElement.
-      \sa Esri::ArcGISRuntime::Toolkit::TextPopupElementViewController
+      \internal
+    This class is an internal implementation detail and is subject to change.
     */
     property var controller: null
 


### PR DESCRIPTION
This just covered the new classes, helpers, qml files etc. that have been added for PopupElements. I left PopupView/Controller class as is for now. Did a local doc build and everything looks good.