### PR TITLE
don-toolkit-instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This toolkit is an open source resource intended for use with the ArcGIS Maps SDK for Qt. It provides ready made components to complement mapping and GIS applications. Because it is open source you are encouraged to modify these tools and add your own.
 
+Before you can utilize the toolkit, you should first ensure your development machine meets the [system requirements](https://developers.arcgis.com/qt/reference/system-requirements/) and has the ArcGIS Maps SDK for Qt properly [installed and set up](https://developers.arcgis.com/qt/install-and-set-up/). TIP: the toolkit requires the installation of the **Qt WebEngine** which can be found under **Select Components > Extensions** section of the Qt installer.
+
 ## Using this toolkit
 
 To use the toolkit, you need to copy this repository onto your development machine.

--- a/uitools/toolkitcpp/README.md
+++ b/uitools/toolkitcpp/README.md
@@ -112,7 +112,7 @@ These are the **Qt Quick UI components/QML Type** available to use:
 > ...
 >
 > ...
-> // Locate this secton in your project
+> // Locate this section in your project
 > Item {
 >    // Create MapQuickView here, and create its Map etc. in C++ code
 >    MapView {

--- a/uitools/toolkitcpp/README.md
+++ b/uitools/toolkitcpp/README.md
@@ -53,10 +53,9 @@ These are the **Qt Quick UI components/QML Type** available to use:
 
 > ```qmake
 > ...
-> # Locate this existing line in your project
-> include($$PWD/arcgisruntime.pri) 
+> include($$PWD/arcgisruntime.pri) # <-- Locate this existing line in your project
 >
-> # Include this toolkit pri qmake file directly afterwards
+> # Include the path to the toolkitcpp.pri file on your device, for example:
 > include(C:/arcgis-maps-sdk-toolkit-qt/toolkit/uitools/toolkitcpp/toolkitcpp.pri)
 > ...
 > ```  
@@ -86,18 +85,16 @@ These are the **Qt Quick UI components/QML Type** available to use:
 
 > ```cpp
 > ...
-> // Locate this existing line in your project
-> #include <QQmlApplicationEngine>
+> #include <QQmlApplicationEngine> // <-- Locate this existing line in your project
 >
-> // Include register.h file directly afterwards
+> // Include the register.h file for the Qt toolkit
 > #include "Esri/ArcGISRuntime/Toolkit/register.h"
 > ...
 >
 > ...
-> // Locate this existing line in your project
-> QQmlApplicationEngine engine;
+> QQmlApplicationEngine engine; // <-- Locate this existing line in your project
 >
-> // Register the toolkit directly afterwards
+> // Register the Qt toolkit
 > Esri::ArcGISRuntime::Toolkit::registerComponents(engine);
 > ...
 > ```
@@ -108,15 +105,14 @@ These are the **Qt Quick UI components/QML Type** available to use:
 
 > ```qml
 > ...
-> // Locate this existing line in your project
-> import Esri.TestNorthArrow
+> import Esri.TestNorthArrow // <-- Locate this existing line in your project
 >
 > // Needed for the Qt toolkit
 > import Esri.ArcGISRuntime.Toolkit
 > ...
 >
 > ...
-> // Locate this existing line in your project
+> // Locate this secton in your project
 > Item {
 >    // Create MapQuickView here, and create its Map etc. in C++ code
 >    MapView {

--- a/uitools/toolkitwidgets/README.md
+++ b/uitools/toolkitwidgets/README.md
@@ -48,10 +48,9 @@ A good way to start using the toolkit is to use one of the ArcGIS Maps SDK for Q
 > For example:
 > ```qmake
 > ...
-> # Locate this existing line in your project
-> include($$PWD/arcgisruntime.pri)
-> .
-> # Include the path to the toolkit.pri file
+> include($$PWD/arcgisruntime.pri) # <-- Locate this existing line in your project
+> 
+> # Include the path to the toolkitcpp.pri file on your device, for example:
 > include(C:/arcgis-maps-sdk-toolkit-qt/toolkit/uitools/toolkitwidgets/toolkitwidgets.pri)
 > ...
 > ```  
@@ -80,13 +79,12 @@ A good way to start using the toolkit is to use one of the ArcGIS Maps SDK for Q
 **STEP 5:** Once you have successfully included the toolkit, you can create individual tools in your own widgets files. In your widgets code file (for example: `TestNorthArrow.cpp`), create a new instance of the tool you wish to use and add it to your widgets layout. You will also normally need to pass the `GeoView` which the tool is designed to work with:
 
 > ```cpp
-> // Locate this existing line in your project
-> #include "Esri/ArcGISRuntime/Toolkit/NorthArrow.h"
+> #include "Esri/ArcGISRuntime/Toolkit/NorthArrow.h" // <-- Locate this existing line in your project
 >  ...
 >
+> // Add your the NorthArrow to your UI.
 > auto northArrow = new Esri::ArcGISRuntime::Toolkit::NorthArrow(this);
 > northArrow->setMapView(m_mapView);
-> // Add your NorthArrow to your UI here!
 > ```
 
 **STEP 6:** When you run your app, you should now see the UI for the Qt toolkit component in your app. For example:

--- a/uitools/toolkitwidgets/README.md
+++ b/uitools/toolkitwidgets/README.md
@@ -93,6 +93,7 @@ A good way to start using the toolkit is to use one of the ArcGIS Maps SDK for Q
 > auto northArrow = new Esri::ArcGISRuntime::Toolkit::NorthArrow(this);
 > northArrow->setMapView(m_mapView);
 > northArrow->setFixedSize(100,100); // The default is 48x48 pixels.
+> northArrow->move(this->width() + 40, this->height() - 10); // Additional code needed if the app window is resized.
 > ...
 > ```
 

--- a/uitools/toolkitwidgets/README.md
+++ b/uitools/toolkitwidgets/README.md
@@ -79,12 +79,20 @@ A good way to start using the toolkit is to use one of the ArcGIS Maps SDK for Q
 **STEP 5:** Once you have successfully included the toolkit, you can create individual tools in your own widgets files. In your widgets code file (for example: `TestNorthArrow.cpp`), create a new instance of the tool you wish to use and add it to your widgets layout. You will also normally need to pass the `GeoView` which the tool is designed to work with:
 
 > ```cpp
-> #include "Esri/ArcGISRuntime/Toolkit/NorthArrow.h" // <-- Locate this existing line in your project
->  ...
+> ...
+> #include "MapTypes.h" // <-- Locate this existing line in your project
 >
-> // Add your the NorthArrow to your UI.
+> // Add the header for the Qt toolkit control.
+> #include "Esri/ArcGISRuntime/Toolkit/NorthArrow.h"
+> ...
+>
+> ...
+> setCentralWidget(m_mapView);  // <-- Locate this existing line in your project
+>
+> // Add the NorthArrow to your UI.
 > auto northArrow = new Esri::ArcGISRuntime::Toolkit::NorthArrow(this);
 > northArrow->setMapView(m_mapView);
+> northArrow->setFixedSize(100,100); // The default is 48x48 pixels.
 > ```
 
 **STEP 6:** When you run your app, you should now see the UI for the Qt toolkit component in your app. For example:

--- a/uitools/toolkitwidgets/README.md
+++ b/uitools/toolkitwidgets/README.md
@@ -48,9 +48,10 @@ A good way to start using the toolkit is to use one of the ArcGIS Maps SDK for Q
 > For example:
 > ```qmake
 > ...
-> include($$PWD/arcgisruntime.pri) # <-- Locate this existing line in your project
-> 
-> # Include the path to the toolkitcpp.pri file on your device, for example:
+> # Locate this existing line in your project
+> include($$PWD/arcgisruntime.pri)
+> .
+> # Include the path to the toolkit.pri file
 > include(C:/arcgis-maps-sdk-toolkit-qt/toolkit/uitools/toolkitwidgets/toolkitwidgets.pri)
 > ...
 > ```  
@@ -79,22 +80,13 @@ A good way to start using the toolkit is to use one of the ArcGIS Maps SDK for Q
 **STEP 5:** Once you have successfully included the toolkit, you can create individual tools in your own widgets files. In your widgets code file (for example: `TestNorthArrow.cpp`), create a new instance of the tool you wish to use and add it to your widgets layout. You will also normally need to pass the `GeoView` which the tool is designed to work with:
 
 > ```cpp
-> ...
-> #include "MapTypes.h" // <-- Locate this existing line in your project
->
-> // Add the header for the Qt toolkit control.
+> // Locate this existing line in your project
 > #include "Esri/ArcGISRuntime/Toolkit/NorthArrow.h"
-> ...
+>  ...
 >
-> ...
-> setCentralWidget(m_mapView);  // <-- Locate this existing line in your project
->
-> // Add the NorthArrow to your UI.
 > auto northArrow = new Esri::ArcGISRuntime::Toolkit::NorthArrow(this);
 > northArrow->setMapView(m_mapView);
-> northArrow->setFixedSize(100,100); // The default is 48x48 pixels.
-> northArrow->move(this->width() + 40, this->height() - 10); // Additional code needed if the app window is resized.
-> ...
+> // Add your NorthArrow to your UI here!
 > ```
 
 **STEP 6:** When you run your app, you should now see the UI for the Qt toolkit component in your app. For example:

--- a/uitools/toolkitwidgets/README.md
+++ b/uitools/toolkitwidgets/README.md
@@ -93,6 +93,7 @@ A good way to start using the toolkit is to use one of the ArcGIS Maps SDK for Q
 > auto northArrow = new Esri::ArcGISRuntime::Toolkit::NorthArrow(this);
 > northArrow->setMapView(m_mapView);
 > northArrow->setFixedSize(100,100); // The default is 48x48 pixels.
+> ...
 > ```
 
 **STEP 6:** When you run your app, you should now see the UI for the Qt toolkit component in your app. For example:


### PR DESCRIPTION
Clarification on Qt toolkit usage (Qt Quick UI components) instructions for `v.next` for the pages:
- https://github.com/Esri/arcgis-maps-sdk-toolkit-qt/blob/don-toolkit-instructions/uitools/toolkitcpp/README.md

This would benefit the changes currently in the toolkit for issue:
- https://devtopia.esri.com/runtime/qt/issues/5314