### PR TITLE
Update UtilityNetworkTraceController.cpp

### DIFF
--- a/uitools/common/src/UtilityNetworkTraceController.cpp
+++ b/uitools/common/src/UtilityNetworkTraceController.cpp
@@ -851,6 +851,8 @@ void UtilityNetworkTraceController::setupUtilityNetworks()
           {
             //single shot connection
             QMetaObject::Connection* const connection = new QMetaObject::Connection;
+            QT_WARNING_PUSH
+            QT_WARNING_DISABLE_MSVC(4573)
             *connection = connect(un, &UtilityNetwork::doneLoading, this, [connection](const Error& e)
             {
               if (!e.isEmpty())
@@ -862,6 +864,7 @@ void UtilityNetworkTraceController::setupUtilityNetworks()
               QObject::disconnect(*connection);
               delete connection;
             });
+            QT_WARNING_POP
             un->load();
           }
         }


### PR DESCRIPTION
Fix C4573 warning in window. This warning is a false positive. When there is mix of static functions and non static functions (`QObject::disconnect` in this case), MSVC confuses the functions and requires to capture `this` for static functions. This PR is to silent this warning.