### PR TITLE
Remove unused TaskWatcher includes

### DIFF
--- a/uitools/common/src/BookmarksViewController.cpp
+++ b/uitools/common/src/BookmarksViewController.cpp
@@ -30,7 +30,6 @@
 #include <BookmarkListModel.h>
 #include <Map.h>
 #include <Scene.h>
-#include <TaskWatcher.h>
 
 namespace Esri::ArcGISRuntime::Toolkit {
 

--- a/uitools/common/src/FloorFilterController.cpp
+++ b/uitools/common/src/FloorFilterController.cpp
@@ -28,7 +28,6 @@
 #include <Layer.h>
 #include <Map.h>
 #include <Scene.h>
-#include <TaskWatcher.h>
 #include <Viewpoint.h>
 
 // Toolkit headers

--- a/uitools/common/src/SearchSourceInterface.h
+++ b/uitools/common/src/SearchSourceInterface.h
@@ -19,7 +19,6 @@
 // ArcGISRuntime headers
 #include <Geometry.h>
 #include <Point.h>
-#include <TaskWatcher.h>
 
 // Qt headers
 #include <QList>

--- a/uitools/common/src/UtilityNetworkTraceController.cpp
+++ b/uitools/common/src/UtilityNetworkTraceController.cpp
@@ -41,7 +41,6 @@
 #include <SpatialReference.h>
 #include <Symbol.h>
 #include <SymbolTypes.h>
-#include <TaskWatcher.h>
 #include <UtilityAssetGroup.h>
 #include <UtilityAssetType.h>
 #include <UtilityElement.h>


### PR DESCRIPTION
Remove unused include directives for `TaskWatcher`.

Verified this locally on macOS and Windows with our `UiToolsExamples` app.