### PR TITLE
Deprecate all the AR components.

### DIFF
--- a/augmented_reality/ArApi/ArApi.pri
+++ b/augmented_reality/ArApi/ArApi.pri
@@ -16,11 +16,13 @@
 
 # This configuration file is an internal file.
 # To use the AR features of the ArcGIS Runtime Toolkit for Qt,
-# uses the files ArApi.pri to use C++ API. See AR.md for details.
+# use the file ArApi.pri to use C++ API. See AR.md for details.
 
 isEmpty(ARCGIS_TOOLKIT_PATH) {
     error(ARCGIS_TOOLKIT_PATH is not set)
 }
+
+warning("The Augmented Reality (AR) toolkit components are deprecated and will be removed in a future release.")
 
 AUGMENTED_REALITY_PATH = $$ARCGIS_TOOLKIT_PATH/augmented_reality
 

--- a/augmented_reality/ArApi/include/Android/ArCoreFrameRenderer.h
+++ b/augmented_reality/ArApi/include/Android/ArCoreFrameRenderer.h
@@ -17,6 +17,10 @@
 #ifndef ArCoreFrameRenderer_H
 #define ArCoreFrameRenderer_H
 
+// C++ API headers
+#include "Deprecated.h"
+
+// Qt headers
 #include <QOpenGLFunctions>
 #include <QOpenGLShaderProgram>
 
@@ -24,7 +28,7 @@ namespace Esri::ArcGISRuntime::Toolkit::Internal {
 
 class ArCoreWrapper;
 
-class ArCoreFrameRenderer : public QOpenGLFunctions
+class QRT_DEPRECATED ArCoreFrameRenderer : public QOpenGLFunctions
 {
 public:
   ArCoreFrameRenderer(ArCoreWrapper* arCoreWrapper);

--- a/augmented_reality/ArApi/include/Android/ArCorePlaneRenderer.h
+++ b/augmented_reality/ArApi/include/Android/ArCorePlaneRenderer.h
@@ -17,15 +17,19 @@
 #ifndef ArCorePlaneRenderer_H
 #define ArCorePlaneRenderer_H
 
+// C++ API headers
+#include "Deprecated.h"
+
+// Qt headers
+#include <QColor>
 #include <QOpenGLFunctions>
 #include <QOpenGLShaderProgram>
-#include <QColor>
 
 namespace Esri::ArcGISRuntime::Toolkit::Internal {
 
 class ArCoreWrapper;
 
-class ArCorePlaneRenderer : public QOpenGLFunctions
+class QRT_DEPRECATED ArCorePlaneRenderer : public QOpenGLFunctions
 {
 public:
   ArCorePlaneRenderer(ArCoreWrapper* arCoreWrapper);

--- a/augmented_reality/ArApi/include/Android/ArCorePointCloudRenderer.h
+++ b/augmented_reality/ArApi/include/Android/ArCorePointCloudRenderer.h
@@ -17,15 +17,19 @@
 #ifndef ArCorePointCloudRenderer_H
 #define ArCorePointCloudRenderer_H
 
+// C++ API headers
+#include "Deprecated.h"
+
+// Qt headers
+#include <QColor>
 #include <QOpenGLFunctions>
 #include <QOpenGLShaderProgram>
-#include <QColor>
 
 namespace Esri::ArcGISRuntime::Toolkit::Internal {
 
 class ArCoreWrapper;
 
-class ArCorePointCloudRenderer : public QOpenGLFunctions
+class QRT_DEPRECATED ArCorePointCloudRenderer : public QOpenGLFunctions
 {
 public:
   ArCorePointCloudRenderer(ArCoreWrapper* arCoreWrapper);

--- a/augmented_reality/ArApi/include/Android/ArCoreWrapper.h
+++ b/augmented_reality/ArApi/include/Android/ArCoreWrapper.h
@@ -17,11 +17,17 @@
 #ifndef ArCoreWrapper_H
 #define ArCoreWrapper_H
 
+// C++ API headers
+#include "Deprecated.h"
+
+// Qt headers
 #include <QJniEnvironment>
-#include <QSize>
-#include <QTimer>
 #include <QMatrix4x4>
 #include <QOpenGLFunctions>
+#include <QSize>
+#include <QTimer>
+
+// STL headers
 #include <array>
 
 // forward declaration of AR core types to avoid include "arcore_c_api.h" here.
@@ -42,7 +48,7 @@ class ArCoreFrameRenderer;
 class ArCorePointCloudRenderer;
 class ArCorePlaneRenderer;
 
-class ArCoreWrapper
+class QRT_DEPRECATED ArCoreWrapper
 {
 
 public:

--- a/augmented_reality/ArApi/include/ArEnums.h
+++ b/augmented_reality/ArApi/include/ArEnums.h
@@ -17,13 +17,17 @@
 #ifndef ArEnums_H
 #define ArEnums_H
 
+// C++ API headers
+#include "Deprecated.h"
+
+// Qt headers
 #include <QObject>
 
 namespace Esri::ArcGISRuntime::Toolkit::ArEnums
 {
   Q_NAMESPACE
 
-  enum class LocationTrackingMode
+  enum class QRT_DEPRECATED LocationTrackingMode
   {
     Ignore = 0,
     Initial = 1,
@@ -31,7 +35,7 @@ namespace Esri::ArcGISRuntime::Toolkit::ArEnums
   };
   Q_ENUM_NS(LocationTrackingMode)
 
-  enum class SensorStatus
+  enum class QRT_DEPRECATED SensorStatus
   {
     Stopped = 0,
     Starting = 1,

--- a/augmented_reality/ArApi/include/ArWrapper.h
+++ b/augmented_reality/ArApi/include/ArWrapper.h
@@ -17,9 +17,15 @@
 #ifndef ARWRAPPER_H
 #define ARWRAPPER_H
 
-#include <QtGlobal>
-#include <QSize>
+// C++ API headers
+#include "Deprecated.h"
+
+// Qt headers
 #include <QColor>
+#include <QSize>
+#include <QtGlobal>
+
+// STL headers
 #include <array>
 
 #if defined Q_OS_IOS
@@ -44,7 +50,7 @@ class ArWrapper : public ArCoreWrapper { using ArCoreWrapper::ArCoreWrapper; };
 #else
 
 // default implementation for desktop platforms.
-class ArWrapper
+class QRT_DEPRECATED ArWrapper
 {
 public:
   ArWrapper(void*);

--- a/augmented_reality/ArApi/include/ArcGISArView.h
+++ b/augmented_reality/ArApi/include/ArcGISArView.h
@@ -17,8 +17,12 @@
 #ifndef ArcGISArView_H
 #define ArcGISArView_H
 
+// toolkit headers
 #include "ArcGISArViewInterface.h"
+
+// C++ API headers
 #include "Camera.h"
+#include "Deprecated.h"
 #include "SceneQuickView.h"
 
 Q_MOC_INCLUDE("Point.h")
@@ -29,7 +33,7 @@ class TransformationMatrixCameraController;
 
 namespace Toolkit {
 
-class ArcGISArView : public ArcGISArViewInterface
+class QRT_DEPRECATED ArcGISArView : public ArcGISArViewInterface
 {
   Q_OBJECT
 

--- a/augmented_reality/ArApi/include/ArcGISArViewInterface.h
+++ b/augmented_reality/ArApi/include/ArcGISArViewInterface.h
@@ -17,9 +17,17 @@
 #ifndef ArcGISArViewInterface_H
 #define ArcGISArViewInterface_H
 
-#include <QQuickFramebufferObject>
-#include "LocationDataSource.h"
+// toolkit headers
 #include "ArEnums.h"
+#include "LocationDataSource.h"
+
+// C++ API headers
+#include "Deprecated.h"
+
+// Qt headers
+#include <QQuickFramebufferObject>
+
+// STL headers
 #include <array>
 #include <memory>
 
@@ -30,7 +38,7 @@ class ArWrapper;
 class ArcGISArViewRenderer;
 }
 
-class ArcGISArViewInterface : public QQuickFramebufferObject
+class QRT_DEPRECATED ArcGISArViewInterface : public QQuickFramebufferObject
 {
   Q_OBJECT
   Q_PROPERTY(bool tracking READ tracking WRITE setTracking NOTIFY trackingChanged)

--- a/augmented_reality/ArApi/include/ArcGISArViewRenderer.h
+++ b/augmented_reality/ArApi/include/ArcGISArViewRenderer.h
@@ -17,6 +17,10 @@
 #ifndef ArcGISArViewRenderer_H
 #define ArcGISArViewRenderer_H
 
+// C++ API headers
+#include "Deprecated.h"
+
+// Qt headers
 #include <QQuickFramebufferObject>
 
 class QQuickWindow;
@@ -25,7 +29,7 @@ namespace Esri::ArcGISRuntime::Toolkit::Internal {
 
 class ArWrapper;
 
-class ArcGISArViewRenderer : public QQuickFramebufferObject::Renderer
+class QRT_DEPRECATED ArcGISArViewRenderer : public QQuickFramebufferObject::Renderer
 {
 public:
   ArcGISArViewRenderer(Internal::ArWrapper* arWrapper = nullptr);

--- a/augmented_reality/ArApi/include/LocationDataSource.h
+++ b/augmented_reality/ArApi/include/LocationDataSource.h
@@ -17,8 +17,14 @@
 #ifndef LocationDataSource_H
 #define LocationDataSource_H
 
-#include <QObject>
+// toolkit headers
 #include "ArEnums.h"
+
+// C++ API headers
+#include "Deprecated.h"
+
+// Qt headers
+#include <QObject>
 
 class QCompass;
 class QGeoPositionInfoSource;
@@ -28,7 +34,7 @@ Q_MOC_INCLUDE("QGeoPositionInfoSource")
 
 namespace Esri::ArcGISRuntime::Toolkit {
 
-class LocationDataSource : public QObject
+class QRT_DEPRECATED LocationDataSource : public QObject
 {
   Q_OBJECT
 

--- a/augmented_reality/ArApi/include/iOS/ArKitFrameRenderer.h
+++ b/augmented_reality/ArApi/include/iOS/ArKitFrameRenderer.h
@@ -17,6 +17,10 @@
 #ifndef ArKitFrameRenderer_H
 #define ArKitFrameRenderer_H
 
+// C++ API headers
+#include "Deprecated.h"
+
+// Qt headers
 #include <QOpenGLFunctions>
 #include <QOpenGLTexture>
 
@@ -24,7 +28,7 @@ class QOpenGLShaderProgram;
 
 namespace Esri::ArcGISRuntime::Toolkit::Internal {
 
-class ArKitFrameRenderer : public QOpenGLFunctions
+class QRT_DEPRECATED ArKitFrameRenderer : public QOpenGLFunctions
 {
 public:
   ArKitFrameRenderer();

--- a/augmented_reality/ArApi/include/iOS/ArKitPlaneRenderer.h
+++ b/augmented_reality/ArApi/include/iOS/ArKitPlaneRenderer.h
@@ -17,13 +17,17 @@
 #ifndef ArKitPlaneRenderer_H
 #define ArKitPlaneRenderer_H
 
+// C++ API headers
+#include "Deprecated.h"
+
+// Qt headers
 #include <QOpenGLFunctions>
 
 namespace Esri::ArcGISRuntime::Toolkit::Internal {
 
 class ArKitWrapper;
 
-class ArKitPlaneRenderer : public QOpenGLFunctions
+class QRT_DEPRECATED ArKitPlaneRenderer : public QOpenGLFunctions
 {
 public:
   ArKitPlaneRenderer(ArKitWrapper* ArKitWrapper);

--- a/augmented_reality/ArApi/include/iOS/ArKitPointCloudRenderer.h
+++ b/augmented_reality/ArApi/include/iOS/ArKitPointCloudRenderer.h
@@ -17,9 +17,13 @@
 #ifndef ArKitPointCloudRenderer_H
 #define ArKitPointCloudRenderer_H
 
+// C++ API headers
+#include "Deprecated.h"
+
+// Qt headers
+#include <QColor>
 #include <QOpenGLFunctions>
 #include <QOpenGLShaderProgram>
-#include <QColor>
 
 class QOpenGLShaderProgram;
 
@@ -28,7 +32,7 @@ namespace Esri::ArcGISRuntime::Toolkit::Internal {
 class ArKitWrapper;
 
 // This class renders the detected point cloud into the view.
-class ArKitPointCloudRenderer : public QOpenGLFunctions
+class QRT_DEPRECATED ArKitPointCloudRenderer : public QOpenGLFunctions
 {
 public:
   ArKitPointCloudRenderer(ArKitWrapper* ArKitWrapper);

--- a/augmented_reality/ArApi/include/iOS/ArKitUtils.h
+++ b/augmented_reality/ArApi/include/iOS/ArKitUtils.h
@@ -16,10 +16,11 @@
 
 #import <ARKit/ARKit.h>
 #include <QString>
+#include "Deprecated.h"
 
 namespace Esri::ArcGISRuntime::Toolkit::ArKitUtils {
 
-QString worldMappingStatusToString(ARWorldMappingStatus status)
+QRT_DEPRECATED QString worldMappingStatusToString(ARWorldMappingStatus status)
 {
   switch (status)
   {
@@ -36,7 +37,7 @@ QString worldMappingStatusToString(ARWorldMappingStatus status)
   }
 }
 
-QString worldMappingStatusToDescription(ARWorldMappingStatus status)
+QRT_DEPRECATED QString worldMappingStatusToDescription(ARWorldMappingStatus status)
 {
   switch (status)
   {
@@ -53,7 +54,7 @@ QString worldMappingStatusToDescription(ARWorldMappingStatus status)
   }
 }
 
-QString trackingStateToString(ARTrackingState trackingState)
+QRT_DEPRECATED QString trackingStateToString(ARTrackingState trackingState)
 {
   switch (trackingState)
   {
@@ -68,7 +69,7 @@ QString trackingStateToString(ARTrackingState trackingState)
   }
 }
 
-QString trackingStateToDescription(ARTrackingState trackingState)
+QRT_DEPRECATED QString trackingStateToDescription(ARTrackingState trackingState)
 {
   switch (trackingState)
   {
@@ -83,7 +84,7 @@ QString trackingStateToDescription(ARTrackingState trackingState)
   }
 }
 
-QString trackingStateReasonToString(ARTrackingStateReason trackingStateReason)
+QRT_DEPRECATED QString trackingStateReasonToString(ARTrackingStateReason trackingStateReason)
 {
   switch (trackingStateReason)
   {
@@ -102,7 +103,7 @@ QString trackingStateReasonToString(ARTrackingStateReason trackingStateReason)
   }
 }
 
-QString trackingStateReasonToDescription(ARTrackingStateReason trackingStateReason)
+QRT_DEPRECATED QString trackingStateReasonToDescription(ARTrackingStateReason trackingStateReason)
 {
   switch (trackingStateReason)
   {
@@ -123,7 +124,7 @@ QString trackingStateReasonToDescription(ARTrackingStateReason trackingStateReas
   }
 }
 
-QString arErrorCodeToString(ARErrorCode errorCode)
+QRT_DEPRECATED QString arErrorCodeToString(ARErrorCode errorCode)
 {
   switch (errorCode)
   {
@@ -158,7 +159,7 @@ QString arErrorCodeToString(ARErrorCode errorCode)
   }
 }
 
-QString arErrorCodeToDescription(ARErrorCode errorCode)
+QRT_DEPRECATED QString arErrorCodeToDescription(ARErrorCode errorCode)
 {
   switch (errorCode)
   {

--- a/augmented_reality/ArApi/include/iOS/ArKitWrapper.h
+++ b/augmented_reality/ArApi/include/iOS/ArKitWrapper.h
@@ -17,9 +17,13 @@
 #ifndef ArKitWrapper_H
 #define ArKitWrapper_H
 
-#include <QtGlobal>
-#include <QSizeF>
+// C++ API headers
+#include "Deprecated.h"
+
+// Qt headers
 #include <QMatrix4x4>
+#include <QSizeF>
+#include <QtGlobal>
 
 namespace Esri::ArcGISRuntime::Toolkit {
 
@@ -31,7 +35,7 @@ class ArKitFrameRenderer;
 class ArKitPlaneRenderer;
 class ArKitPointCloudRenderer;
 
-class ArKitWrapper
+class QRT_DEPRECATED ArKitWrapper
 {
 public:
   ArKitWrapper(ArcGISArViewInterface* arcGISArView);

--- a/augmented_reality/ArApi/qdoc/LocationTrackingMode.qdoc
+++ b/augmented_reality/ArApi/qdoc/LocationTrackingMode.qdoc
@@ -19,6 +19,8 @@
   \title LocationTrackingMode enumeration
   \since Esri::ArcGISRuntime 100.6
 
+  \deprecated
+
   Enumerates options for using locations generated from the location data
   source during AR tracking. The LocationTrackingMode can be one of:
   \table

--- a/augmented_reality/ArApi/qdoc/SensorStatus.qdoc
+++ b/augmented_reality/ArApi/qdoc/SensorStatus.qdoc
@@ -21,6 +21,8 @@
   \inmodule ArcGISQtToolkit
   \since Esri::ArcGISRuntime 100.6
 
+  \deprecated
+
   Enumerates the status of a sensor. The SensorStatus can be one of:
   \table
     \header

--- a/augmented_reality/README.md
+++ b/augmented_reality/README.md
@@ -1,5 +1,10 @@
 [![ArcGIS Maps SDK for Qt Toolkit API reference](https://img.shields.io/badge/API_Reference-purple)](https://developers.arcgis.com/qt/latest/toolkit/api-reference/) [![ArcGIS Maps SDK for Qt](https://img.shields.io/badge/ArcGIS%20Maps%20SDK%20for%20Qt-0b5394)](https://developers.arcgis.com/qt/) [![ArcGIS Maps SDK for Qt toolkit](https://img.shields.io/badge/ArcGIS%20Maps%20SDK%20for%20Qt%20toolkit-ea4d13)](https://github.com/Esri/arcgis-maps-sdk-toolkit-qt)
 
+# Deprecation notice
+
+The ArcGIS Maps SDK for Qt Augmented Reality toolkit components are deprecated
+and will be removed in a future release.
+
 # Augmented Reality toolkit components
 
 The Augmented Reality (AR) toolkit components provide support for ARKit for iOS


### PR DESCRIPTION
This PR deprecates in doc and in code all AR components. Anyone using the pri file will get a qmake warning as well as compiler warnings.