### PR TITLE
Deprecate the older popup system

### DIFF
--- a/uitools/common/src/PopupViewController.cpp
+++ b/uitools/common/src/PopupViewController.cpp
@@ -68,10 +68,12 @@ Popup* PopupViewController::popup() const
 {
   return m_popup;
 }
+
 GenericListModel* PopupViewController::popupElementControllers() const
 {
   return m_popupElementControllerModel;
 }
+
 void PopupViewController::setPopup(Popup* popup)
 {
   if (m_popup == popup)
@@ -125,6 +127,7 @@ void PopupViewController::setPopup(Popup* popup)
   emit popupChanged();
   emit titleChanged();
 }
+
 void PopupViewController::setPopupManager(PopupManager* popupManager)
 {
   if (popupManager == m_popupManager)

--- a/uitools/common/src/PopupViewController.h
+++ b/uitools/common/src/PopupViewController.h
@@ -21,7 +21,8 @@
 #include <QObject>
 #include <QPointer>
 
-// STL headers
+// Maps SDK headers
+#include <Deprecated.h>
 #include <Popup.h>
 #include <PopupElement.h>
 #include <PopupManager.h>
@@ -65,9 +66,9 @@ public:
 
   GenericListModel* popupElementControllers() const;
 
-  PopupManager* popupManager() const;
+  QRT_DEPRECATED PopupManager* popupManager() const;
 
-  void setPopupManager(PopupManager* popupManager);
+  QRT_DEPRECATED void setPopupManager(PopupManager* popupManager);
 
   QAbstractListModel* displayFields() const;
 
@@ -87,7 +88,7 @@ signals:
 
   void popupChanged();
 
-  void popupManagerChanged();
+  QRT_DEPRECATED void popupManagerChanged();
 
   void titleChanged();
 

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/PopupStackView.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/PopupStackView.qml
@@ -60,6 +60,7 @@ import QtQuick.Layouts
    \note Each time a change is made to the Popup, PopupDefinition,
    PopupManager, or any of their properties, the popupManagers must be
    re-set to the PopupStackView.
+   \deprecate
  */
 Pane {
     id: popupStackView

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/PopupStackView.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/PopupStackView.qml
@@ -60,7 +60,7 @@ import QtQuick.Layouts
    \note Each time a change is made to the Popup, PopupDefinition,
    PopupManager, or any of their properties, the popupManagers must be
    re-set to the PopupStackView.
-   \deprecate
+   \deprecated
  */
 Pane {
     id: popupStackView

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
@@ -70,6 +70,7 @@ Page {
 
        The PopupManager should be created from a Popup.
        \qmlproperty PopupManager popupManager
+       \deprecated
      */
     property var popupManager: null
 
@@ -77,8 +78,6 @@ Page {
        \brief The Popup that controls the information being displayed in
        the view.
 
-       If both a Popup and PopupManager are provided, the Popup will take priority
-       which utilizes the new PopupElements.
        \qmlproperty Popup popup
      */
     property var popup: null


### PR DESCRIPTION
Since the entirety of `PopupViewController`'s doc has been removed, there isn't much to do there in the doc.