### PR TITLE
fix popup view scroll behavior

### DIFF
--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
@@ -155,6 +155,14 @@ Page {
      */
     signal imageClicked(var sourceUrl, var linkUrl)
 
+    MouseArea {
+        anchors.fill: parent
+        // stop whell event from scrolling the map once we reach the end of the PopupView
+        onWheel: (event) => {
+            event.accepted = true;
+        }
+    }
+
     Binding {
         target: controller
         property: "popupManager"


### PR DESCRIPTION
Prevents the wheel event from propagating from the PopupView to the MapView.