### PR TITLE
fix menu separators. consistent across all views.

### DIFF
--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/AttachmentsPopupElementView.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/AttachmentsPopupElementView.qml
@@ -99,12 +99,6 @@ ColumnLayout {
         }
     }
 
-    MenuSeparator {
-        Layout.fillWidth: true
-        Layout.leftMargin: attachmentsPopupElementView.mediaMargin
-        Layout.rightMargin: attachmentsPopupElementView.mediaMargin
-    }
-
     ListView {
         clip: true
         interactive: false
@@ -172,6 +166,11 @@ ColumnLayout {
                 columnSpacing: 5
                 rowSpacing: 0
 
+                MenuSeparator {
+                    Layout.fillWidth: true
+                    Layout.columnSpan: 3
+                }
+
                 Image {
                     fillMode: Image.PreserveAspectFit
                     Layout.preferredHeight: fileInfoColumn.height
@@ -215,11 +214,6 @@ ColumnLayout {
                     running: model.listModelData.fetchingAttachment
                     visible: model.listModelData.fetchingAttachment
                     Layout.maximumHeight: fileInfoColumn.height
-                }
-
-                MenuSeparator {
-                    Layout.fillWidth: true
-                    Layout.columnSpan: 3
                 }
             }
         }

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
@@ -394,12 +394,6 @@ Page {
                             controller: listModelData
                             width: elementsView.width
                         }
-
-                        MenuSeparator {
-                            width: elementsView.width
-                            leftPadding: 10
-                            rightPadding: 10
-                        }
                     }
                 }
             }


### PR DESCRIPTION
Adjusted the menu separators. Attachments was doing the same thing so I made the fix there as well. 
![2025-03-27_14-00-39](https://github.com/user-attachments/assets/1d48b603-8fe6-44a1-b052-9e1ba5b79d52)
![2025-03-27_14-00-49](https://github.com/user-attachments/assets/00e4a54f-91a9-41ba-85ff-0c28817c1bfb)
![2025-03-27_14-01-09](https://github.com/user-attachments/assets/84e1b626-b10f-4905-b6a4-38276540458c)
