### PR TITLE
Add the iOS workaround.

### DIFF
--- a/uitools/examples/UitoolsExamples.pro
+++ b/uitools/examples/UitoolsExamples.pro
@@ -71,6 +71,32 @@ macx {
 
 ios {
     include (iOS/iOS.pri)
+
+    # workaround for https://bugreports.qt.io/browse/QTBUG-129651
+    # ArcGIS Maps SDK for Qt adds 'QMAKE_RPATHDIR = @executable_path/Frameworks'
+    # and ffmpeg frameworks have embedded '@rpath/Frameworks' path.
+    # so in order for them to be found, we need to add @executable_path to the
+    # search path.
+    FFMPEG_LIB_DIR = $$absolute_path($$replace(QMAKE_QMAKE, "qmake6", "../../ios/lib/ffmpeg"))
+    FFMPEG_LIB_DIR = $$absolute_path($$replace(FFMPEG_LIB_DIR, "qmake", "../../ios/lib/ffmpeg"))
+    QMAKE_LFLAGS += -F$${FFMPEG_LIB_DIR} -Wl,-rpath,@executable_path
+    versionAtLeast(QT_VERSION, 6.8.3) {
+      FRAMEWORK = "xcframework"
+    } else {
+      FRAMEWORK = "framework"
+    }
+    LIBS += -framework libavcodec \
+            -framework libavformat \
+            -framework libavutil \
+            -framework libswresample \
+            -framework libswscale
+    ffmpeg.files = $${FFMPEG_LIB_DIR}/libavcodec.$${FRAMEWORK} \
+                   $${FFMPEG_LIB_DIR}/libavformat.$${FRAMEWORK} \
+                   $${FFMPEG_LIB_DIR}/libavutil.$${FRAMEWORK} \
+                   $${FFMPEG_LIB_DIR}/libswresample.$${FRAMEWORK} \
+                   $${FFMPEG_LIB_DIR}/libswscale.$${FRAMEWORK}
+    ffmpeg.path = Frameworks
+    QMAKE_BUNDLE_DATA += ffmpeg
 }
 
 android {


### PR DESCRIPTION
We are missing this workaround for the UITools example.

I followed the same pattern of https://github.com/Esri/arcgis-maps-sdk-samples-qt/pull/1792/files.