### PR TITLE
Disable deprecation warnings for PopupViewController.cpp

### DIFF
--- a/uitools/common/src/PopupViewController.cpp
+++ b/uitools/common/src/PopupViewController.cpp
@@ -14,6 +14,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ******************************************************************************/
+#define QRT_DISABLE_DEPRECATED_WARNINGS
+
 #include "PopupViewController.h"
 
 // Qt headers


### PR DESCRIPTION
Disable deprecation warnings stemming from our internal `PopupViewController.cpp` source file.