### PR TITLE
Have onExit for hover dismiss the tooltip immediately.

### DIFF
--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
@@ -343,14 +343,8 @@ Pane {
                     timerOnEntered.start();
                 }
 
-                // When mouse exits thumbnail area, use timer to delay hiding of tooltip.
                 onExited: {
-                    timerOnEntered.stop();
-                    // Create a definition for the hideTooltipFn property of timerOnExited
-                    timerOnExited.hideTooltipFn = () => {
-                        basemapDelegate.ToolTip.visible = false;
-                    }
-                    timerOnExited.start();
+                    basemapDelegate.ToolTip.visible = false;
                 }
             }
         }
@@ -367,19 +361,6 @@ Pane {
         onTriggered: {
             if (showTooltipFn)
                 showTooltipFn();
-        }
-    }
-
-    Timer {
-        id: timerOnExited
-
-        property var hideTooltipFn: null;
-
-        interval: Qt.styleHints.mousePressAndHoldInterval * 1.9
-        repeat: false
-        onTriggered: {
-            if (hideTooltipFn)
-                hideTooltipFn();
         }
     }
 


### PR DESCRIPTION
I don't see value in having it hang out after someone moves away from it, and there are bugs with it.

There was a timing problem with the onEnter and onExit signals when moving between the items. The logic assume we will receive onExit, then onEnter (in that order) but occasionally it happens in reverse order. The onExit logic stop the timer than displays the tooltip.

This fix changes the behavior so that when moving away from any item, its tooltip will be hidden immediately.