### PR TITLE
Disable hover on mobile.

### DIFF
--- a/calcite/Calcite/ItemDelegate.qml
+++ b/calcite/Calcite/ItemDelegate.qml
@@ -13,6 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ******************************************************************************/
+import QtQml
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Controls.impl
@@ -20,6 +21,14 @@ import QtQuick.Templates as T
 
 T.ItemDelegate {
     id: control
+
+    Component.onCompleted: {
+        // disable hover behavior on mobile
+        const platform = Qt.platform.os;
+        if (platform === "android" || platform === "ios") {
+            hoverEnabled = false;
+        }
+    }
 
     implicitWidth: Math.max(background ? background.implicitWidth : 0,
                             contentItem.implicitWidth + leftPadding + rightPadding)


### PR DESCRIPTION
This fixes an issue on mobile platforms where navigating the list with touch behaves oddly when hover is enabled. Hover isn't a mobile concept; you are either touching or not touching, so disable hover on mobile platforms.