### PR TITLE
Only define this if it's not already defined.

### DIFF
--- a/uitools/common/src/PopupViewController.cpp
+++ b/uitools/common/src/PopupViewController.cpp
@@ -14,7 +14,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ******************************************************************************/
+#ifndef QRT_DISABLE_DEPRECATED_WARNINGS
 #define QRT_DISABLE_DEPRECATED_WARNINGS
+#endif
 
 #include "PopupViewController.h"
 


### PR DESCRIPTION
Avoids "QRT_DISABLE_DEPRECATED_WARNINGS" redefined

This is failing our checks job because of the redefinition.