### PR TITLE
Aji13187/removed private browser session

### DIFF
--- a/uitools/common/src/ArcGISAuthenticationController.cpp
+++ b/uitools/common/src/ArcGISAuthenticationController.cpp
@@ -76,7 +76,6 @@ ArcGISAuthenticationController::ArcGISAuthenticationController(QObject* parent) 
     currentOAuthUserLoginPrompt->setParent(nullptr);
     m_currentOAuthUserLoginPrompt = std::unique_ptr<OAuthUserLoginPrompt>{currentOAuthUserLoginPrompt};
     emit authorizeUrlChanged();
-    emit preferPrivateWebBrowserSessionChanged();
     emit redirectUriChanged();
     emit displayOAuthSignInView();
   });
@@ -396,11 +395,6 @@ QString ArcGISAuthenticationController::currentAuthenticatingHost_() const
 QUrl ArcGISAuthenticationController::authorizeUrl_() const
 {
   return m_currentOAuthUserLoginPrompt ? m_currentOAuthUserLoginPrompt->authorizeUrl() : QUrl{};
-}
-
-bool ArcGISAuthenticationController::preferPrivateWebBrowserSession_() const
-{
-  return m_currentOAuthUserLoginPrompt ? m_currentOAuthUserLoginPrompt->preferPrivateWebBrowserSession() : false;
 }
 
 QString ArcGISAuthenticationController::redirectUri_() const

--- a/uitools/common/src/ArcGISAuthenticationController.h
+++ b/uitools/common/src/ArcGISAuthenticationController.h
@@ -53,7 +53,6 @@ class ArcGISAuthenticationController : public QObject
 
   // OAuth
   Q_PROPERTY(QUrl authorizeUrl READ authorizeUrl_ NOTIFY authorizeUrlChanged)
-  Q_PROPERTY(bool preferPrivateWebBrowserSession READ preferPrivateWebBrowserSession_ NOTIFY preferPrivateWebBrowserSessionChanged)
   Q_PROPERTY(QString redirectUri READ redirectUri_ NOTIFY redirectUriChanged)
 
   Q_PROPERTY(int previousFailureCount READ previousFailureCount_ NOTIFY previousFailureCountChanged)
@@ -108,7 +107,6 @@ signals:
   void displayServerTrustView();
   void currentAuthenticatingHostChanged();
   void authorizeUrlChanged();
-  void preferPrivateWebBrowserSessionChanged();
   void redirectUriChanged();
   void previousFailureCountChanged();
 
@@ -117,7 +115,6 @@ private:
   bool canBeUsed_() const;
   QString currentAuthenticatingHost_() const;
   QUrl authorizeUrl_() const;
-  bool preferPrivateWebBrowserSession_() const;
   QString redirectUri_() const;
   int previousFailureCount_() const;
 


### PR DESCRIPTION
We cannot launch browser in private/incognito mode, so removed `preferPrivateWebBrowserSession` property references.