### PR TITLE
Guil8553/network auth

### DIFF
--- a/uitools/toolkitcpp/CMakeLists.txt
+++ b/uitools/toolkitcpp/CMakeLists.txt
@@ -18,7 +18,7 @@ include(../common/CMakeLists.txt)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-find_package(Qt6 REQUIRED COMPONENTS Core Gui QuickControls2 Svg WebView Graphs)
+find_package(Qt6 REQUIRED COMPONENTS Core Gui QuickControls2 Svg WebView Graphs NetworkAuth)
 
 qt_standard_project_setup()
 
@@ -45,6 +45,7 @@ target_link_libraries(libtoolkitcpp PRIVATE
     Qt6::Svg
     Qt6::WebView
     Qt6::Graphs
+    Qt6::NetworkAuth
     ArcGISRuntime::Cpp
 )
 

--- a/uitools/toolkitwidgets/CMakeLists.txt
+++ b/uitools/toolkitwidgets/CMakeLists.txt
@@ -18,7 +18,7 @@ include(../common/CMakeLists.txt)
 
 set(CMAKE_AUTOUIC ON)
 
-find_package(Qt6 REQUIRED COMPONENTS Core Gui Svg WebEngineWidgets Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Svg WebEngineWidgets Widgets NetworkAuth)
 
 qt_standard_project_setup()
 
@@ -93,6 +93,7 @@ target_link_libraries(libtoolkitwidgets PRIVATE
     Qt6::Svg
     Qt6::WebEngineWidgets
     Qt6::Widgets
+    Qt6::NetworkAuth
     ArcGISRuntime::Cpp
 )
 

--- a/uitools/toolkitwidgets/toolkitwidgets.pri
+++ b/uitools/toolkitwidgets/toolkitwidgets.pri
@@ -18,7 +18,7 @@ android|ios {
     error("toolkitwidgets.pri is not usable on mobile platforms.")
 }
 
-QT += widgets webenginewidgets svg
+QT += widgets webenginewidgets svg networkauth
 
 TOOLKITWIDGETS_BASE_SRC = $$PWD/src
 TOOLKITWIDGETS_TOOLKIT_SRC = $$TOOLKITWIDGETS_BASE_SRC/Esri/ArcGISRuntime/Toolkit


### PR DESCRIPTION
No issue. Fix builds for widget API and cmake.

networkauth module was recently added in toolkitcpp.pri, but not in toolkitwidgets.pri and cmake files. This breaks the build on CI ("checks" job) and local machine when all.pro is used. 