### PR TITLE
Run continuations on the object's thread.

### DIFF
--- a/uitools/common/src/BasemapGalleryController.cpp
+++ b/uitools/common/src/BasemapGalleryController.cpp
@@ -55,8 +55,8 @@ namespace Esri::ArcGISRuntime::Toolkit {
       \internal
       Takes a map or scene, and connects to it and its basemap.
       Emits a basemapChanged signal when:
-        - The map/scene basemapChanged signal fires.
-        - The basemap load status has changed.
+      - The map/scene basemapChanged signal fires.
+      - The basemap load status has changed.
 
       We automatically disconnect from the map/scene's old basemap if the
       map/scene basemapChanged signal is fired.
@@ -140,7 +140,7 @@ namespace Esri::ArcGISRuntime::Toolkit {
       1. We listen for GalleryItem changes.
       2. We force the basemap to load if not already.
       3. We emit BasemapGalleryController::currentBasemapChanged if the current basemap was
-         added to the gallery.
+      added to the gallery.
      */
     void onBasemapAddedToGallery(BasemapGalleryController* self, GenericListModel* gallery, const QModelIndex& index, BasemapGalleryItem* galleryItem)
     {
@@ -183,7 +183,7 @@ namespace Esri::ArcGISRuntime::Toolkit {
 
       1. We disconnect from the GalleryItem.
       2. We emit BasemapGalleryController::currentBasemapChanged if the current basemap was
-         removed from the gallery.
+      removed from the gallery.
       3. We delete the GalleryItem if we are the parent.
      */
     void onBasemapRemovedFromGallery(BasemapGalleryController* self, BasemapGalleryItem* galleryItem)
@@ -253,7 +253,7 @@ namespace Esri::ArcGISRuntime::Toolkit {
                          if (!e.isEmpty())
                            return;
 
-                         portal->fetchDeveloperBasemapsAsync().then(
+                         portal->fetchDeveloperBasemapsAsync().then(self,
                          [portal, self]()
                          {
                            // Sort and append the basemaps to the gallery.
@@ -265,7 +265,7 @@ namespace Esri::ArcGISRuntime::Toolkit {
 
                          if (qobject_cast<Scene*>(self->geoModel()))
                          {
-                           portal->fetch3DBasemapsAsync().then(
+                           portal->fetch3DBasemapsAsync().then(self,
                                  [portal, self]()
                            {
                              // Sort and append the basemaps to the gallery.
@@ -428,7 +428,7 @@ namespace Esri::ArcGISRuntime::Toolkit {
                  }
                  else
                  {
-                   m_portal->fetchBasemapsAsync().then(
+                   m_portal->fetchBasemapsAsync().then(this,
                    [this]()
                    {
                      BasemapListModel* basemaps = m_portal->basemaps();
@@ -448,7 +448,7 @@ namespace Esri::ArcGISRuntime::Toolkit {
                    }
                    else
                    {
-                     m_portal->fetch3DBasemapsAsync().then(
+                     m_portal->fetch3DBasemapsAsync().then(this,
                      [this]()
                      {
                        BasemapListModel* basemaps = m_portal->basemaps3D();

--- a/uitools/common/src/PopupAttachmentItem.cpp
+++ b/uitools/common/src/PopupAttachmentItem.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  *  Copyright 2012-2025 Esri
  *
@@ -139,7 +140,7 @@ void PopupAttachmentItem::downloadAttachment()
 {
   m_fetchingAttachment = true;
   emit popupAttachmentItemChanged();
-  m_popupAttachment->attachment()->fetchDataAsync().then([this] (const QByteArray& attachmentData)
+  m_popupAttachment->attachment()->fetchDataAsync().then(this, [this] (const QByteArray& attachmentData)
   {
     if (attachmentData.isEmpty())
     {


### PR DESCRIPTION
This can cause problems if we don't when there's a need to set parents across thread on new objects.

In the case of BasemapGallery, new items were being created on a non-UI thread, resulting in a crash:
```
QQmlEngine: Illegal attempt to connect to Esri::ArcGISRuntime::Toolkit::BasemapGalleryItem(0x600002c6e6f0) that is in a different thread than the QML engine QQmlApplicationEngine(0x16ddbeee8.
17:15:04: The process crashed.
```

These changes fix that crash.