### PR TITLE
continueAndFailWithError is deprecated and replaced with continueWithError

### DIFF
--- a/uitools/common/src/AuthenticatorController.cpp
+++ b/uitools/common/src/AuthenticatorController.cpp
@@ -279,8 +279,10 @@ void AuthenticatorController::continueWithUsernamePasswordArcGIS_(const QString&
       return;
     }
     emit previousFailureCountChanged();
-    m_currentArcGISChallenge->continueWithError(e.error());
-    m_currentArcGISChallenge.reset();
+    auto* arcgisChallenge = m_currentArcGISChallenge.release();
+    arcgisChallenge->setParent(this);
+    arcgisChallenge->deleteLater();
+    arcgisChallenge->continueWithError(e.error());
   });
 }
 

--- a/uitools/common/src/AuthenticatorController.cpp
+++ b/uitools/common/src/AuthenticatorController.cpp
@@ -143,7 +143,7 @@ void AuthenticatorController::handleArcGISAuthenticationChallenge(ArcGISAuthenti
           return;
         }
 
-        m_currentArcGISChallenge->continueAndFailWithError(e.error());
+        m_currentArcGISChallenge->continueWithError(e.error());
         m_currentArcGISChallenge.reset();
       });
 
@@ -191,7 +191,7 @@ void AuthenticatorController::handleNetworkAuthenticationChallenge(NetworkAuthen
             QStringLiteral("Only the openssl backend supports Client Certificates (PKI).");
 
         qWarning() << error;
-        m_currentNetworkChallenge->continueAndFailWithError(Error{error, ""});
+        m_currentNetworkChallenge->continueWithError(Error{error, ""});
         m_currentNetworkChallenge.reset();
         return;
       }
@@ -221,7 +221,7 @@ void AuthenticatorController::continueWithServerTrust(bool trust)
   }
   else
   {
-    m_currentNetworkChallenge->continueAndFailWithError(
+    m_currentNetworkChallenge->continueWithError(
         Error{"A ServerTrust challenge was issued, but was blocked by the user", ""});
   }
 
@@ -291,7 +291,7 @@ void AuthenticatorController::continueWithUsernamePasswordArcGIS_(const QString&
     if (m_arcGISPreviousFailureCountsForUrl[requestUrl] >= s_maxArcGISPreviousFailureCount)
     {
       m_arcGISPreviousFailureCountsForUrl.remove(requestUrl);
-      m_currentArcGISChallenge->continueAndFailWithError(e.error());
+      m_currentArcGISChallenge->continueWithError(e.error());
       m_currentArcGISChallenge.reset();
       return;
     }

--- a/uitools/common/src/AuthenticatorController.cpp
+++ b/uitools/common/src/AuthenticatorController.cpp
@@ -135,6 +135,7 @@ void AuthenticatorController::handleArcGISAuthenticationChallenge(ArcGISAuthenti
         }
 
         m_currentArcGISChallenge->continueWithCredential(credential);
+        m_currentArcGISChallenge.reset();
       }).onFailed(this, [this](const ErrorException& e)
       {
         if (!m_currentArcGISChallenge)
@@ -144,6 +145,7 @@ void AuthenticatorController::handleArcGISAuthenticationChallenge(ArcGISAuthenti
 
         emit previousFailureCountChanged();
         m_currentArcGISChallenge->continueWithError(e.error());
+        m_currentArcGISChallenge.reset();
       });
 
       return;
@@ -269,6 +271,7 @@ void AuthenticatorController::continueWithUsernamePasswordArcGIS_(const QString&
                                std::nullopt).then(this, [this](TokenCredential* credential)
   {
     m_currentArcGISChallenge->continueWithCredential(credential);
+    m_currentArcGISChallenge.reset();
   }).onFailed(this, [this](const ErrorException& e)
   {
     if (!m_currentArcGISChallenge)
@@ -278,6 +281,7 @@ void AuthenticatorController::continueWithUsernamePasswordArcGIS_(const QString&
     emit previousFailureCountChanged();
     m_currentArcGISChallenge->continueWithError(e.error());
     emit displayUsernamePasswordSignInView();
+    m_currentArcGISChallenge.reset();
   });
 }
 

--- a/uitools/common/src/AuthenticatorController.cpp
+++ b/uitools/common/src/AuthenticatorController.cpp
@@ -280,7 +280,6 @@ void AuthenticatorController::continueWithUsernamePasswordArcGIS_(const QString&
     }
     emit previousFailureCountChanged();
     m_currentArcGISChallenge->continueWithError(e.error());
-    emit displayUsernamePasswordSignInView();
     m_currentArcGISChallenge.reset();
   });
 }

--- a/uitools/common/src/AuthenticatorController.cpp
+++ b/uitools/common/src/AuthenticatorController.cpp
@@ -144,8 +144,10 @@ void AuthenticatorController::handleArcGISAuthenticationChallenge(ArcGISAuthenti
         }
 
         emit previousFailureCountChanged();
+        auto* arcgisChallenge = m_currentArcGISChallenge.release();
+        arcgisChallenge->setParent(this);
+        arcgisChallenge->deleteLater();
         m_currentArcGISChallenge->continueWithError(e.error());
-        m_currentArcGISChallenge.reset();
       });
 
       return;

--- a/uitools/common/src/AuthenticatorController.h
+++ b/uitools/common/src/AuthenticatorController.h
@@ -132,9 +132,6 @@ private:
   Esri::ArcGISRuntime::Authentication::OAuthUserConfiguration* m_currentOAuthUserConfiguration = nullptr;
   std::unique_ptr<Authentication::OAuthUserLoginPrompt> m_currentOAuthUserLoginPrompt;
 
-  // ArcGISAuthenticationChallenges only. NetworkAuthenticationChallenges already contain this information
-  QHash<QUrl, int> m_arcGISPreviousFailureCountsForUrl;
-  static inline constexpr int s_maxArcGISPreviousFailureCount = 5;
   std::mutex m_mutex;
 };
 


### PR DESCRIPTION
Replaced the deprecated `continueAndFailWithError` with `continueWithError`