### PR TITLE
Fix typo.

### DIFF
--- a/uitools/common/src/AuthenticatorController.cpp
+++ b/uitools/common/src/AuthenticatorController.cpp
@@ -147,7 +147,7 @@ void AuthenticatorController::handleArcGISAuthenticationChallenge(ArcGISAuthenti
         auto* arcgisChallenge = m_currentArcGISChallenge.release();
         arcgisChallenge->setParent(this);
         arcgisChallenge->deleteLater();
-        m_currentArcGISChallenge->continueWithError(e.error());
+        arcgisChallenge->continueWithError(e.error());
       });
 
       return;


### PR DESCRIPTION
Quick fix. This was just a typo. `m_currentArcGISChallenge.release();` was previously called, so we need to call into `arcgisChallenge` now.