### PR TITLE
Add internal test helper.

### DIFF
--- a/uitools/common/src/AuthenticatorController.cpp
+++ b/uitools/common/src/AuthenticatorController.cpp
@@ -17,6 +17,7 @@
 #include "AuthenticatorController.h"
 
 // Qt headers
+#include <QDebug>
 #include <QDesktopServices>
 #include <QFuture>
 #include <QOAuthUriSchemeReplyHandler>
@@ -172,7 +173,15 @@ void AuthenticatorController::handleNetworkAuthenticationChallenge(NetworkAuthen
   {
     case NetworkChallengeType::ServerTrust:
     {
-      emit displayAuthenticatorServerTrustView();
+      if (m_acceptAllServerTrustChallengesForTesting)
+      {
+        qWarning() << "FOR TESTING PURPOSES ONLY - Automatically accepting server trust challenge for" << m_currentNetworkChallenge->host();
+        continueWithServerTrust(true);
+      }
+      else
+      {
+        emit displayAuthenticatorServerTrustView();
+      }
       return;
     }
     case NetworkChallengeType::Basic: [[fallthrough]];
@@ -461,6 +470,12 @@ void AuthenticatorController::finishOAuthExternalBrowserChallengeFlow_()
 {
   m_currentOAuthUserConfiguration = nullptr;
   m_currentOAuthUserLoginPrompt.reset();
+}
+
+void AuthenticatorController::acceptAllServerTrustChallengesForTesting_()
+{
+  qWarning() << "FOR TESTING PURPOSES ONLY - Automatically accepting all server trust challenges.";
+  m_acceptAllServerTrustChallengesForTesting = true;
 }
 
 } //  Esri::ArcGISRuntime::Toolkit

--- a/uitools/common/src/AuthenticatorController.h
+++ b/uitools/common/src/AuthenticatorController.h
@@ -110,6 +110,7 @@ signals:
   void previousFailureCountChanged();
 
 private:
+  friend class ToolkitTester;
   explicit AuthenticatorController(QObject* parent = nullptr);
   bool canBeUsed_() const;
   QString currentAuthenticatingHost_() const;
@@ -123,6 +124,11 @@ private:
   void continueWithUsernamePasswordArcGIS_(const QString& username, const QString& password);
   void continueWithUsernamePasswordNetwork_(const QString& username, const QString& password);
 
+  // For use in automated test environments when it's not part of the workflow being tested,
+  // but needs to be handled regardless. This accepts all server trust challenges and
+  // the dialog will never appear.
+  void acceptAllServerTrustChallengesForTesting_();
+
   std::unique_ptr<ArcGISAuthenticationChallengeRelay> m_arcGISAuthenticationChallengeRelay;
   std::unique_ptr<NetworkAuthenticationChallengeRelay> m_networkAuthenticationChallengeRelay;
 
@@ -131,6 +137,7 @@ private:
   QList<Esri::ArcGISRuntime::Authentication::OAuthUserConfiguration*> m_userConfigurations;
   Esri::ArcGISRuntime::Authentication::OAuthUserConfiguration* m_currentOAuthUserConfiguration = nullptr;
   std::unique_ptr<Authentication::OAuthUserLoginPrompt> m_currentOAuthUserLoginPrompt;
+  bool m_acceptAllServerTrustChallengesForTesting = false;
 
   std::mutex m_mutex;
 };


### PR DESCRIPTION
In some automated tests, we will get the server trust challenge. That is fine, but when we're not testing that we should be able to silently ignore it.

There are inherent risks with allowing any way to disable or bypassing challenges. I feel this is ok because:
1. The intent is clear - this is a private method that can only be accessed by a friend method that doesn't exist in this codebase.
2. This class is not meant to be used directly anyways, and we internally document it can change any time.
3. This repo is open source. We cannot prevent misuse (purposeful or otherwise) since anyone can clone the repo and change anything they want.

If someone does manage to accidentally invoke this test-only functionality, it will loudly log to the console this is for testing purposes only. We will see that in all our automated tests that use this.