### PR TITLE
Jared/popup doc fixmain

### DIFF
--- a/uitools/examples/qml/demos/PopupViewDemoForm.qml
+++ b/uitools/examples/qml/demos/PopupViewDemoForm.qml
@@ -21,30 +21,6 @@ import Esri.ArcGISRuntime.Toolkit
 import DemoApp
 
 DemoPage {
-    sceneViewContents: Component {
-        SceneView {
-            id: view
-
-            //! [Set up Popup View QML]
-            PopupView {
-                id:popupView
-                anchors {
-                     left: parent.left
-                     top: parent.top
-                     bottom: parent.bottom
-                }
-                visible: false
-                popupManager: model.popupManager
-            }
-            //! [Set up Popup View QML]
-
-            PopupViewDemo {
-                id: model
-                geoView : view
-                onPopupManagerChanged : popupView.visible = true;
-            }
-        }
-    }
 
     mapViewContents: Component {
         MapView {
@@ -53,19 +29,20 @@ DemoPage {
             PopupView {
                 id:popupView
                 anchors {
-                     left: parent.left
-                     top: parent.top
-                     bottom: parent.bottom
+                    left: parent.left
+                    top: parent.top
+                    bottom: parent.bottom
                 }
                 visible: false
-                popupManager: model.popupManager
+                popup: model.popup
             }
 
             PopupViewDemo {
                 id: model
                 geoView : view
-                onPopupManagerChanged: popupView.visible = true;
+                onPopupChanged: popupView.visible = true;
             }
+
         }
     }
 }

--- a/uitools/examples/qml/demos/PopupViewDemoForm.qml
+++ b/uitools/examples/qml/demos/PopupViewDemoForm.qml
@@ -22,6 +22,32 @@ import DemoApp
 
 DemoPage {
 
+    sceneViewContents: Component {
+        SceneView {
+            id: view
+
+            //! [Set up Popup View QML]
+            PopupView {
+                id:popupView
+                anchors {
+                     left: parent.left
+                     top: parent.top
+                     bottom: parent.bottom
+                }
+                visible: false
+                popup: model.popup
+            }
+            //! [Set up Popup View QML]
+
+            PopupViewDemo {
+                id: model
+                geoView : view
+                onPopupChanged: popupView.visible = true;
+            }
+        }
+    }
+
+
     mapViewContents: Component {
         MapView {
             id: view

--- a/uitools/examples/qml/demos/PopupViewDemoForm.qml
+++ b/uitools/examples/qml/demos/PopupViewDemoForm.qml
@@ -21,7 +21,6 @@ import Esri.ArcGISRuntime.Toolkit
 import DemoApp
 
 DemoPage {
-
     sceneViewContents: Component {
         SceneView {
             id: view

--- a/uitools/examples/src/demos/PopupViewDemo.cpp
+++ b/uitools/examples/src/demos/PopupViewDemo.cpp
@@ -60,6 +60,20 @@ Esri::ArcGISRuntime::Map* PopupViewDemo::initMap_(QObject* parent) const
                  parent);
 }
 
+Scene* PopupViewDemo::initScene_(QObject* parent) const
+{
+  Scene* scene = BaseDemo::initScene_(parent);
+  Viewpoint viewPoint(Envelope(-122.5277, 37.7204, -122.3511, 37.7956, SpatialReference(4326)));
+  scene->setInitialViewpoint(viewPoint);
+  FeatureLayer* fl = new FeatureLayer(new ServiceFeatureTable(
+                                          QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/"
+                                               "SF311/FeatureServer/0"),
+                                          parent),
+                                      parent);
+  scene->operationalLayers()->append(fl);
+  return scene;
+}
+
 Popup* PopupViewDemo::popup()
 {
   return m_popup;
@@ -106,15 +120,15 @@ void PopupViewDemo::setUp()
 
                         m_featureLayer->clearSelection();
 
-                        const auto popups = identifyResult->popups();
+                        const auto geoElements = identifyResult->geoElements();
 
-                        if (popups.length() == 0)
+                        if (geoElements.length() == 0)
                         {
-                          qDebug() << "no popups";
+                          qDebug() << "no geoElements";
                           return;
                         }
 
-                        const auto popup = popups.first();
+                        const auto popup = new Popup(geoElements.first(), this);
                         popup->setParent(this);
 
                         if (auto element = popup->geoElement())

--- a/uitools/examples/src/demos/PopupViewDemo.cpp
+++ b/uitools/examples/src/demos/PopupViewDemo.cpp
@@ -131,9 +131,13 @@ void PopupViewDemo::setUp()
                         const auto popup = new Popup(geoElements.first(), this);
                         popup->setParent(this);
 
+                        if (popup->title().isEmpty())
+                        {
+                          popup->popupDefinition()->setTitle(identifyResult->layerContent()->name());
+                        }
+
                         if (auto element = popup->geoElement())
                         {
-                          // add the element to the list and take ownership of it.
                           Feature* feature = static_cast<Feature*>(element);
                           m_featureLayer->selectFeature(feature);
                         }

--- a/uitools/examples/src/demos/PopupViewDemo.h
+++ b/uitools/examples/src/demos/PopupViewDemo.h
@@ -41,6 +41,7 @@ public:
 
 protected:
   Esri::ArcGISRuntime::Map* initMap_(QObject* parent) const override;
+  Esri::ArcGISRuntime::Scene* initScene_(QObject* parent) const override;
 
 signals:
   void popupChanged();

--- a/uitools/examples/src/demos/PopupViewDemo.h
+++ b/uitools/examples/src/demos/PopupViewDemo.h
@@ -17,17 +17,23 @@
 #ifndef ARCGIS_RUNTIME_TOOLKIT_CPP_QUICK_DEMO_POPUPVIEWDEMO_H
 #define ARCGIS_RUNTIME_TOOLKIT_CPP_QUICK_DEMO_POPUPVIEWDEMO_H
 
-#include "BaseDemo.h"
+// C++ API headers
 #include "FeatureLayer.h"
+#include "Popup.h"
 #include "PopupManager.h"
 
+// Qt headers
 #include <QObject>
 #include <QQmlEngine>
+
+// Other headers
+#include "BaseDemo.h"
 
 class PopupViewDemo : public BaseDemo
 {
   Q_OBJECT
-  Q_PROPERTY(QObject* popupManager READ popupManager_ WRITE setPopupManager_ NOTIFY popupManagerChanged)
+  Q_PROPERTY(Esri::ArcGISRuntime::Popup* popup READ popup WRITE setPopup NOTIFY popupChanged)
+
   QML_ELEMENT
 public:
   Q_INVOKABLE PopupViewDemo(QObject* parent = nullptr);
@@ -35,21 +41,20 @@ public:
 
 protected:
   Esri::ArcGISRuntime::Map* initMap_(QObject* parent) const override;
-  Esri::ArcGISRuntime::Scene* initScene_(QObject* parent) const override;
 
 signals:
-  void popupManagerChanged();
+  void popupChanged();
 
 private slots:
   void setUp();
 
 private:
-  QObject* popupManager_();
-  void setPopupManager_(QObject* popupManager);
+  Esri::ArcGISRuntime::Popup* popup();
+  void setPopup(Esri::ArcGISRuntime::Popup* popup);
 
 private:
   Esri::ArcGISRuntime::FeatureLayer* m_featureLayer = nullptr;
-  QObject* m_popupManager = nullptr;
+  Esri::ArcGISRuntime::Popup* m_popup = nullptr;
 };
 
 #endif // ARCGIS_RUNTIME_TOOLKIT_CPP_QUICK_DEMO_POPUPVIEWDEMO_H

--- a/uitools/toolkitcpp/docs/PopupView.md
+++ b/uitools/toolkitcpp/docs/PopupView.md
@@ -5,7 +5,7 @@
 The [PopupView - Qt Quick UI/QML Type](https://developers.arcgis.com/qt/toolkit/api-reference/qml-esri-arcgisruntime-toolkit-popupview.html) control provides a view for displaying information about a feature. A PopupView can be used to display information for any type that implements the PopupSource interface. For example, FeatureLayer implements PopupSource. This means that it has a PopupDefinition, which defines how the Popup should look for any features in that layer. An example workflow for displaying a PopupView for a feature in a FeatureLayer would be:
 
 - Declare a PopupView and anchor it to a desired location.
-- Perform an identify operation on a GeoView and select a Popup from the identify result.
+- Perform an identify operation on a GeoView and select a Feature from the identify result.
 - Create a Popup from the Feature.
 - Optionally obtain the Popup's PopupDefinition and set the title, whether to show attachments, and so on.
 - Assign the PopupView's popup property the Popup created in the previous step.

--- a/uitools/toolkitcpp/docs/PopupView.md
+++ b/uitools/toolkitcpp/docs/PopupView.md
@@ -5,8 +5,9 @@
 The [PopupView - Qt Quick UI/QML Type](https://developers.arcgis.com/qt/toolkit/api-reference/qml-esri-arcgisruntime-toolkit-popupview.html) control provides a view for displaying information about a feature. A PopupView can be used to display information for any type that implements the PopupSource interface. For example, FeatureLayer implements PopupSource. This means that it has a PopupDefinition, which defines how the Popup should look for any features in that layer. An example workflow for displaying a PopupView for a feature in a FeatureLayer would be:
 
 - Declare a PopupView and anchor it to a desired location.
-- Perform an identify operation on a GeoView and select a Feature from the identify result.
+- Perform an identify operation on a GeoView and select a Popup from the identify result.
 - Create a Popup from the Feature.
+- Optionally obtain the Popup's PopupDefinition and set the title, whether to show attachments, and so on.
 - Assign the PopupView's popup property the Popup created in the previous step.
 
 The PopupView is a QML Item that can be anchored, given to a dialog, or positioned using XY screen coordinates. Transform, Transition, and other QML animation types can be used to animate the showing and dissmisal of the view. For more information, please see the Popup and PopupManager documentation.

--- a/uitools/toolkitcpp/docs/PopupView.md
+++ b/uitools/toolkitcpp/docs/PopupView.md
@@ -2,17 +2,17 @@
 
 # PopupView - Qt Quick UI/QML Type
 
-The [PopupView - Qt Quick UI/QML Type](https://developers.arcgis.com/qt/toolkit/api-reference/qml-esri-arcgisruntime-toolkit-popupview.html) control provides a view for displaying and editing information about a feature. A PopupView can be used to display information for any type that implements the PopupSource interface. For example, FeatureLayer implements PopupSource. This means that it has a PopupDefinition, which defines how the Popup should look for any features in that layer. An example workflow for displaying a PopupView for a feature in a FeatureLayer would be:
+The [PopupView - Qt Quick UI/QML Type](https://developers.arcgis.com/qt/toolkit/api-reference/qml-esri-arcgisruntime-toolkit-popupview.html) control provides a view for displaying information about a feature. A PopupView can be used to display information for any type that implements the PopupSource interface. For example, FeatureLayer implements PopupSource. This means that it has a PopupDefinition, which defines how the Popup should look for any features in that layer. An example workflow for displaying a PopupView for a feature in a FeatureLayer would be:
 
 - Declare a PopupView and anchor it to a desired location.
 - Perform an identify operation on a GeoView and select a Feature from the identify result.
 - Create a Popup from the Feature.
-- Optionally obtain the Popup's PopupDefinition and set the title, whether to show attachments, and so on.
-- Create a PopupManager from the Popup.
-- Assign the PopupView's popupManager property the PopupManager created in the previous step.
+- Assign the PopupView's popup property the Popup created in the previous step.
 
 The PopupView is a QML Item that can be anchored, given to a dialog, or positioned using XY screen coordinates. Transform, Transition, and other QML animation types can be used to animate the showing and dissmisal of the view. For more information, please see the Popup and PopupManager documentation.
 
-NOTE: Each time a change is made to the Popup, PopupDefinition, PopupManager, or any of their properties, the PopupManager must be re-set to the PopupView.
+NOTE: Each time a change is made to the Popup, PopupDefinition, or any of their properties, the PopupManager must be re-set to the PopupView.
+
+The PopupView 
 
 ![PopupView image](https://developers.arcgis.com/qt/toolkit/api-reference/images/popupview.png)


### PR DESCRIPTION
James brought it to my attention that the markdown doc was incorrect for popupview so I got this change up to fix it. Then decided we should also change over the example app to use it as well which was straight forward even though the data is not interesting.

I want to update the image in the markdown but the url points to `https://developers.arcgis.com/qt/toolkit/api-reference/images/popupview.png` and im not sure how to update this.