### PR TITLE
Toolkit - Added 2D Rotation for NorthArrow example

### DIFF
--- a/uitools/examples/qml/demos/NorthArrowDemoForm.qml
+++ b/uitools/examples/qml/demos/NorthArrowDemoForm.qml
@@ -77,9 +77,7 @@ DemoPage {
                     rightPadding: 5
                     C.Slider {
                         id: slider1
-                        anchors {
-                            verticalCenter: parent.verticalCenter
-                        }
+                        anchors.verticalCenter: parent.verticalCenter
                         // Slider controls degrees of rotation
                         from: 0.0
                         to: 360.0

--- a/uitools/examples/qml/demos/NorthArrowDemoForm.qml
+++ b/uitools/examples/qml/demos/NorthArrowDemoForm.qml
@@ -86,7 +86,7 @@ DemoPage {
                         from: 0.0
                         to: 360.0
 
-                        onPressedChanged: {
+                        onValueChanged: {
                             // Call C++ invokable function to change the rotation
                             // of the map view
                             model.setMapViewRotation(view,value);

--- a/uitools/examples/qml/demos/NorthArrowDemoForm.qml
+++ b/uitools/examples/qml/demos/NorthArrowDemoForm.qml
@@ -19,6 +19,7 @@ import QtQuick.Controls
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 import DemoApp
+import Calcite as C
 
 DemoPage {
     sceneViewContents: Component {
@@ -54,7 +55,56 @@ DemoPage {
                 }
             }
             NorthArrowDemo {
+                id:model
                 geoView: view
+            }
+
+            // Slider UI presentation at bottom
+            Rectangle {
+                anchors {
+                    bottom: view.attributionTop
+                    horizontalCenter: parent.horizontalCenter
+                }
+
+
+                width: childrenRect.width
+                height: childrenRect.height
+                color: C.Calcite.background
+
+                // sliderCombo: A slider and text for its value
+                Row {
+                    id: sliderCombo
+                    spacing: 5
+                    leftPadding: 5
+                    rightPadding: 5
+                    C.Slider {
+                        id: slider1
+                        anchors {
+                            verticalCenter: parent.verticalCenter
+                        }
+                        // Slider controls degrees of rotation
+                        from: 0.0
+                        to: 360.0
+
+                        onPressedChanged: {
+                            // Call C++ invokable function to change the rotation
+                            // of the map view
+                            model.setMapViewRotation(view,value);
+                        }
+                    }
+
+                    Text {
+                        anchors {
+                            verticalCenter: parent.verticalCenter
+                            margins: 10
+                        }
+                        horizontalAlignment: TextInput.AlignHCenter
+                        font.pixelSize: 20
+                        color: C.Calcite.text2
+                        text: slider1.value.toPrecision(3);
+                        width: 40
+                    }
+                }
             }
         }
     }

--- a/uitools/examples/qml/demos/NorthArrowDemoForm.qml
+++ b/uitools/examples/qml/demos/NorthArrowDemoForm.qml
@@ -89,7 +89,7 @@ DemoPage {
                         }
                     }
 
-                    Text {
+                    Label {
                         anchors {
                             verticalCenter: parent.verticalCenter
                             margins: 10

--- a/uitools/examples/qml/demos/NorthArrowDemoForm.qml
+++ b/uitools/examples/qml/demos/NorthArrowDemoForm.qml
@@ -55,7 +55,7 @@ DemoPage {
                 }
             }
             NorthArrowDemo {
-                id:model
+                id: model
                 geoView: view
             }
 

--- a/uitools/examples/qml/demos/NorthArrowDemoForm.qml
+++ b/uitools/examples/qml/demos/NorthArrowDemoForm.qml
@@ -65,8 +65,6 @@ DemoPage {
                     bottom: view.attributionTop
                     horizontalCenter: parent.horizontalCenter
                 }
-
-
                 width: childrenRect.width
                 height: childrenRect.height
                 color: C.Calcite.background

--- a/uitools/examples/qml/demos/NorthArrowDemoForm.qml
+++ b/uitools/examples/qml/demos/NorthArrowDemoForm.qml
@@ -89,7 +89,7 @@ DemoPage {
                         onValueChanged: {
                             // Call C++ invokable function to change the rotation
                             // of the map view
-                            model.setMapViewRotation(view,value);
+                            model.setMapViewRotation(view, value);
                         }
                     }
 

--- a/uitools/examples/src/demos/NorthArrowDemo.cpp
+++ b/uitools/examples/src/demos/NorthArrowDemo.cpp
@@ -16,6 +16,8 @@
 
 #include "NorthArrowDemo.h"
 
+#include <QFuture>
+
 NorthArrowDemo::NorthArrowDemo(QObject* parent) :
   BaseDemo(parent)
 {
@@ -23,4 +25,9 @@ NorthArrowDemo::NorthArrowDemo(QObject* parent) :
 
 NorthArrowDemo::~NorthArrowDemo()
 {
+}
+
+void NorthArrowDemo::setMapViewRotation(Esri::ArcGISRuntime::MapQuickView* mapView, double degrees)
+{
+  mapView->setViewpointRotationAsync(degrees);
 }

--- a/uitools/examples/src/demos/NorthArrowDemo.h
+++ b/uitools/examples/src/demos/NorthArrowDemo.h
@@ -18,6 +18,7 @@
 #define ARCGIS_RUNTIME_TOOLKIT_CPP_QUICK_DEMO_NORTHARROWDEMO_H
 
 #include "BaseDemo.h"
+#include "MapQuickView.h"
 
 #include <QObject>
 #include <QQmlEngine>
@@ -29,6 +30,8 @@ class NorthArrowDemo : public BaseDemo
 public:
   Q_INVOKABLE NorthArrowDemo(QObject* parent = nullptr);
   ~NorthArrowDemo() override;
+
+   Q_INVOKABLE void setMapViewRotation(Esri::ArcGISRuntime::MapQuickView* mapView, double degrees);
 };
 
 #endif // ARCGIS_RUNTIME_TOOLKIT_CPP_QUICK_DEMO_NORTHARROWDEMO_H

--- a/uitools/examples/src/demos/NorthArrowDemo.h
+++ b/uitools/examples/src/demos/NorthArrowDemo.h
@@ -31,7 +31,7 @@ public:
   Q_INVOKABLE NorthArrowDemo(QObject* parent = nullptr);
   ~NorthArrowDemo() override;
 
-   Q_INVOKABLE void setMapViewRotation(Esri::ArcGISRuntime::MapQuickView* mapView, double degrees);
+  Q_INVOKABLE void setMapViewRotation(Esri::ArcGISRuntime::MapQuickView* mapView, double degrees);
 };
 
 #endif // ARCGIS_RUNTIME_TOOLKIT_CPP_QUICK_DEMO_NORTHARROWDEMO_H


### PR DESCRIPTION
- Added rotation slider for the 2d map view mode in the North arrow example.
- used Calcite slider component