### PR TITLE
ToolKit- calcite checkbox unchecked state fix

### DIFF
--- a/calcite/Calcite/CheckIndicator.qml
+++ b/calcite/Calcite/CheckIndicator.qml
@@ -35,7 +35,8 @@ Rectangle {
             fill: parent
             margins: control.checkState === Qt.Checked ? -2 : 2
         }
-        source: control.checkState === Qt.Checked ? "images/check.svg": "images/line-solid.svg"
-        visible: true
+        source: control.checkState === Qt.Checked ? "images/check.svg":
+                control.checkState === Qt.PartiallyChecked ? "images/line-solid.svg": ""
+        visible: control.checkState !== Qt.Unchecked
     }
 }


### PR DESCRIPTION
Calcite checkbox has 3 check states:
- checkState: Qt.Unchecked
- checkState: Qt.Checked
- checkState: Qt.PartiallyChecked

This fix ensures the unchecked state for the calcite checkbox is a empty instead of the "-" which represents an intermediary state.
Follows:[ calcite design system](https://developers.arcgis.com/calcite-design-system/components/checkbox/)