### PR TITLE
Slider resets to 0 when we double click the north arrow.

### DIFF
--- a/uitools/examples/qml/demos/NorthArrowDemoForm.qml
+++ b/uitools/examples/qml/demos/NorthArrowDemoForm.qml
@@ -53,6 +53,9 @@ DemoPage {
                     bottom: parent.attributionTop
                     margins: 10
                 }
+                onHeadingReset:{
+                    slider1.value = 0
+                }
             }
             NorthArrowDemo {
                 id: model
@@ -80,7 +83,7 @@ DemoPage {
                         anchors.verticalCenter: parent.verticalCenter
                         // Slider controls degrees of rotation
                         from: 0.0
-                        to: 360.0
+                        to: 359.0
 
                         onValueChanged: {
                             // Call C++ invokable function to change the rotation

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/NorthArrow.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/NorthArrow.qml
@@ -53,6 +53,12 @@ Item {
     */
     property var controller: NorthArrowController { }
 
+    /*
+      \qmlsignal NorthArrow::headingReset()
+      \brief Signal emitted when the heading is reset to 0 on double click.
+      */
+    signal headingReset()
+
     implicitWidth: 48
 
     implicitHeight: implicitWidth
@@ -80,8 +86,10 @@ Item {
     MouseArea {
         anchors.fill: parent
         onDoubleClicked: {
-            if (geoView)
+            if (geoView){
                 controller.setHeading(0); // Rotate back to north.
+                headingReset();
+            }
         }
     }
 }


### PR DESCRIPTION
- Added a signal to the north arrow component that emits when the heading is reset.
- Slider value now goes from 0 - 359 as 360 is the same as 0.