### PR TITLE
Linter import fixes for Label and BaseMapGallery Label 

### DIFF
--- a/calcite/Calcite/Label.qml
+++ b/calcite/Calcite/Label.qml
@@ -13,6 +13,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ******************************************************************************/
+import QtQuick
+import QtQuick.Controls.impl
 import QtQuick.Templates as T
 
 T.Label {

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
@@ -238,7 +238,7 @@ Pane {
                 }
 
                 // Text display
-                Text {
+                Label {
                     id: basemapLabel
                     anchors.margins: 5
                     width: basemapDelegate.isGrid ? view.cellWidth - anchors.margins * 2 : view.cellWidth - (basemapIcon.width + (anchors.margins * 2) + scrollBar.width)


### PR DESCRIPTION
BaseMapGallery using label instead of text to be theme aware.