### PR TITLE
Change default color values of Callout to palette.base and palette.text

### DIFF
--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/Callout.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/Callout.qml
@@ -73,12 +73,12 @@ import QtQuick.Shapes
 Pane {
     id: root
 
-    background: Rectangle{
-        color: palette.window
-        border.color: palette.windowText
+    background: Rectangle {
+        color: palette.base
+        border.color: palette.text
     }
 
-    property color dynamicTextColor: background.border.color
+    property color dynamicTextColor: palette.text
 
     enum LeaderPosition {
         UpperLeft = 0,


### PR DESCRIPTION
Callout default color values were implemented [here](https://github.com/Esri/arcgis-maps-sdk-toolkit-qt/commit/d5d6de2b6b6ed0e679bb4f722e3e69151df74889) with `palette.window` and `palette.windowText`. `palette.base` is more appropriate for foreground elements.