### PR TITLE
Callout example - remove background rectangle override and callout changes

### DIFF
--- a/uitools/common/images/pin-tear.svg
+++ b/uitools/common/images/pin-tear.svg
@@ -1,1 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><path d="M24.8 11a8.8 8.8 0 0 0-17.6 0v.24C7.2 16.23 12 23 16 30.66c4-7.66 8.8-14.43 8.8-19.42zM16 15a4 4 0 1 1 4-4 4 4 0 0 1-4 4z"/><path fill="none" d="M0 0h32v32H0z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path fill="maroon" d="M24.8 11a8.8 8.8 0 0 0-17.6 0v.24C7.2 16.23 12 23 16 30.66c4-7.66 8.8-14.43 8.8-19.42zM16 15a4 4 0 1 1 4-4 4 4 0 0 1-4 4z"/>
+  <path fill="none" d="M0 0h32v32H0z"/>
+</svg>

--- a/uitools/examples/qml/demos/CalloutDemoForm.qml
+++ b/uitools/examples/qml/demos/CalloutDemoForm.qml
@@ -34,12 +34,6 @@ DemoPage {
                 implicitHeight: 100
                 leaderPosition: Callout.LeaderPosition.Automatic
                 maxWidth: 250
-                background: Rectangle {
-                    radius: 5
-                    border.width: 2
-                    border.color: "black"
-                }
-                palette.windowText: "black"
             }
             //! [Set up Callout QML]
 

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/Callout.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/Callout.qml
@@ -75,10 +75,9 @@ Pane {
 
     background: Rectangle {
         color: palette.base
-        border.color: palette.text
+        border.color: palette.dark
     }
 
-    property color dynamicTextColor: palette.text
 
     enum LeaderPosition {
         UpperLeft = 0,
@@ -298,7 +297,6 @@ Pane {
         Label {
             id: title
             text: calloutData ? calloutData.title : ""
-            color: root.dynamicTextColor
             wrapMode: Text.Wrap
             clip: true
             elide: Text.ElideRight
@@ -362,7 +360,6 @@ Pane {
         Label {
             id: detail
             text: calloutData ? calloutData.detail : ""
-            color: root.dynamicTextColor
             wrapMode: Text.Wrap
             elide: Text.ElideRight
             clip: true


### PR DESCRIPTION
This pr includes the following changes:
- Callout example: Removed background override that was hardcoding the callout color to white.
- Callout component: removed dynamicTextColor property which was [added recently](https://github.com/Esri/arcgis-maps-sdk-toolkit-qt/pull/755). We use "Labels" for text and background uses palette which both react to system theme. Included this change because setting dynamicTextColor property to palette.text does not react to theme changes when the app is open(edge case).
- Updated pin-tear.svg color to maroon which works well in light and dark modes.

Cross checked samples and examples and we are not using dynamicTextColor anywhere so it is safe to remove.