### PR TITLE
Ldanzinger/overview fix

### DIFF
--- a/uitools/common/src/OverviewMapController.cpp
+++ b/uitools/common/src/OverviewMapController.cpp
@@ -22,6 +22,7 @@
 #include "SingleShotConnection.h"
 
 // ArcGISRuntime headers
+#include <Error.h>
 #include <Geometry.h>
 #include <Graphic.h>
 #include <GraphicListModel.h>
@@ -32,6 +33,7 @@
 #include <MapViewTypes.h>
 #include <Point.h>
 #include <Polygon.h>
+#include <Scene.h>
 #include <SimpleFillSymbol.h>
 #include <SimpleLineSymbol.h>
 #include <SimpleMarkerSymbol.h>
@@ -111,6 +113,29 @@ namespace Esri::ArcGISRuntime::Toolkit {
 
     if (auto sceneView = qobject_cast<SceneViewToolkit*>(m_geoView))
     {
+      // set up the inset map once the scene is done loading
+      connect(sceneView->arcGISScene(), &Scene::doneLoading, this, [this, sceneView](Error e)
+              {
+                if (!e.isEmpty())
+                {
+                  qDebug() << "Error. Main map did not load" << e.message() << e.additionalMessage();
+                  return;
+                }
+
+                // create the map
+                auto map = new Map(BasemapStyle::ArcGISTopographic, m_insetView);
+                // set the initial viewpoint (scale = main scene's scale * scaleFactor)
+                const Viewpoint viewpoint = sceneView->currentViewpoint(ViewpointType::CenterAndScale);
+                const Viewpoint newViewpoint{
+                                             geometry_cast<Point>(viewpoint.targetGeometry()),
+                                             viewpoint.targetScale() * scaleFactor()};
+
+                // set the initial viewpoint before setting on the mapview
+                map->setInitialViewpoint(sceneView->arcGISScene()->initialViewpoint());
+                m_insetView->setAttributionTextVisible(false);
+                m_insetView->setMap(map);
+              });
+
       // If Symbol has not yet been set, we provide a default symbol appropriate for SceneViews.
       if (symbol() == nullptr)
       {
@@ -136,6 +161,31 @@ namespace Esri::ArcGISRuntime::Toolkit {
     }
     else if (auto mapView = qobject_cast<MapViewToolkit*>(m_geoView))
     {
+      // set up the inset map once the map is done loading
+      connect(mapView->map(), &Map::doneLoading, this, [this, mapView](Error e)
+              {
+                if (!e.isEmpty())
+                {
+                  qDebug() << "Error. Main map did not load" << e.message() << e.additionalMessage();
+                  return;
+                }
+
+                // create the map
+                auto map = new Map(BasemapStyle::ArcGISTopographic, m_insetView);
+
+                // set the initial viewpoint (scale = main maps's scale * scaleFactor)
+                auto initialViewpoint = mapView->map()->initialViewpoint();
+                const Viewpoint newViewpoint{
+                                             geometry_cast<Point>(initialViewpoint.targetGeometry()),
+                                             initialViewpoint.targetScale() * scaleFactor(),
+                                             initialViewpoint.rotation()};
+
+                // set the initial viewpoint before setting on the mapview
+                map->setInitialViewpoint(newViewpoint);
+                m_insetView->setAttributionTextVisible(false);
+                m_insetView->setMap(map);
+              });
+
       // If Symbol has not yet been set, we provide a default symbol appropriate for MapViews.
       if (symbol() == nullptr)
       {

--- a/uitools/common/src/OverviewMapController.cpp
+++ b/uitools/common/src/OverviewMapController.cpp
@@ -112,6 +112,7 @@ namespace Esri::ArcGISRuntime::Toolkit {
 
     if (auto sceneView = qobject_cast<SceneViewToolkit*>(m_geoView))
     {
+      // create a lambda to handle setting up the inset map and viewpoint
       auto setupInsetMapForScene = [this](SceneViewToolkit* sceneView)
       {
         // create the map
@@ -127,13 +128,14 @@ namespace Esri::ArcGISRuntime::Toolkit {
         m_insetView->setMap(map);
       };
 
+      // if the map is already loaded, setup the inset map
       if (sceneView->arcGISScene()->loadStatus() == LoadStatus::Loaded)
       {
         setupInsetMapForScene(sceneView);
       }
+      // set up the inset map once the scene is done loading
       else
       {
-        // set up the inset map once the scene is done loading
         connect(sceneView->arcGISScene(), &Scene::doneLoading, this, [setupInsetMapForScene, sceneView](Error e)
                 {
                   if (!e.isEmpty())
@@ -171,6 +173,7 @@ namespace Esri::ArcGISRuntime::Toolkit {
     }
     else if (auto mapView = qobject_cast<MapViewToolkit*>(m_geoView))
     {
+      // create a lambda to handle setting up the inset map and viewpoint
       auto setupInsetMapForMap = [this](MapViewToolkit* mapView)
       {
         // create the map
@@ -188,13 +191,14 @@ namespace Esri::ArcGISRuntime::Toolkit {
         m_insetView->setMap(map);
       };
 
+      // if the map is already loaded, setup the inset map
       if (mapView->map()->loadStatus() == LoadStatus::Loaded)
       {
         setupInsetMapForMap(mapView);
       }
+      // set up the inset map once the map is done loading
       else
       {
-        // set up the inset map once the map is done loading
         connect(mapView->map(), &Map::doneLoading, this, [setupInsetMapForMap, mapView](Error e)
                 {
                   if (!e.isEmpty())

--- a/uitools/common/src/OverviewMapController.cpp
+++ b/uitools/common/src/OverviewMapController.cpp
@@ -55,7 +55,7 @@ namespace Esri::ArcGISRuntime::Toolkit {
     QObject(parent),
     m_insetView(new MapViewToolkit),
     m_reticle(new Graphic(this))
-  {    
+  {
     // Disable keyboard interactions, and mouse
     // interactions on devices. Keep track of mouse
     // touches.

--- a/uitools/common/src/OverviewMapController.cpp
+++ b/uitools/common/src/OverviewMapController.cpp
@@ -55,11 +55,7 @@ namespace Esri::ArcGISRuntime::Toolkit {
     QObject(parent),
     m_insetView(new MapViewToolkit),
     m_reticle(new Graphic(this))
-  {
-    // Setup insetViiew defaults.
-    m_insetView->setMap(new Map(BasemapStyle::ArcGISTopographic, m_insetView));
-    m_insetView->setAttributionTextVisible(false);
-
+  {    
     // Disable keyboard interactions, and mouse
     // interactions on devices. Keep track of mouse
     // touches.

--- a/uitools/common/src/OverviewMapController.cpp
+++ b/uitools/common/src/OverviewMapController.cpp
@@ -107,30 +107,43 @@ namespace Esri::ArcGISRuntime::Toolkit {
 
     m_geoView = geoView;
 
+
     if (auto sceneView = qobject_cast<SceneViewToolkit*>(m_geoView))
     {
-      // set up the inset map once the scene is done loading
-      connect(sceneView->arcGISScene(), &Scene::doneLoading, this, [this, sceneView](Error e)
-              {
-                if (!e.isEmpty())
+      auto setupInsetMapForScene = [this](SceneViewToolkit* sceneView)
+      {
+        // create the map
+        auto map = new Map(BasemapStyle::ArcGISTopographic, m_insetView);
+        // set the initial viewpoint (scale = main scene's scale * scaleFactor)
+        const Viewpoint viewpoint = sceneView->currentViewpoint(ViewpointType::CenterAndScale);
+        const Viewpoint newViewpoint{
+                                     geometry_cast<Point>(viewpoint.targetGeometry()),
+                                     viewpoint.targetScale() * scaleFactor()};
+
+        // set the initial viewpoint before setting on the mapview
+        map->setInitialViewpoint(sceneView->arcGISScene()->initialViewpoint());
+        m_insetView->setMap(map);
+        m_insetView->setAttributionTextVisible(false);
+      };
+
+      if (sceneView->arcGISScene()->loadStatus() == LoadStatus::Loaded)
+      {
+        setupInsetMapForScene(sceneView);
+      }
+      else
+      {
+        // set up the inset map once the scene is done loading
+        connect(sceneView->arcGISScene(), &Scene::doneLoading, this, [setupInsetMapForScene, sceneView](Error e)
                 {
-                  qDebug() << "Error. Main map did not load" << e.message() << e.additionalMessage();
-                  return;
-                }
+                  if (!e.isEmpty())
+                  {
+                    qDebug() << "Error. Main map did not load" << e.message() << e.additionalMessage();
+                    return;
+                  }
 
-                // create the map
-                auto map = new Map(BasemapStyle::ArcGISTopographic, m_insetView);
-                // set the initial viewpoint (scale = main scene's scale * scaleFactor)
-                const Viewpoint viewpoint = sceneView->currentViewpoint(ViewpointType::CenterAndScale);
-                const Viewpoint newViewpoint{
-                                             geometry_cast<Point>(viewpoint.targetGeometry()),
-                                             viewpoint.targetScale() * scaleFactor()};
-
-                // set the initial viewpoint before setting on the mapview
-                map->setInitialViewpoint(sceneView->arcGISScene()->initialViewpoint());
-                m_insetView->setAttributionTextVisible(false);
-                m_insetView->setMap(map);
-              });
+                  setupInsetMapForScene(sceneView);
+                });
+      }
 
       // If Symbol has not yet been set, we provide a default symbol appropriate for SceneViews.
       if (symbol() == nullptr)
@@ -157,30 +170,42 @@ namespace Esri::ArcGISRuntime::Toolkit {
     }
     else if (auto mapView = qobject_cast<MapViewToolkit*>(m_geoView))
     {
-      // set up the inset map once the map is done loading
-      connect(mapView->map(), &Map::doneLoading, this, [this, mapView](Error e)
-              {
-                if (!e.isEmpty())
+      auto setupInsetMapForMap = [this](MapViewToolkit* mapView)
+      {
+        // create the map
+        auto map = new Map(BasemapStyle::ArcGISTopographic, m_insetView);
+
+        // set the initial viewpoint (scale = main maps's scale * scaleFactor)
+        auto initialViewpoint = mapView->map()->initialViewpoint();
+        const Viewpoint newViewpoint{
+                                     geometry_cast<Point>(initialViewpoint.targetGeometry()),
+                                     initialViewpoint.targetScale() * scaleFactor(),
+                                     initialViewpoint.rotation()};
+
+        // set the initial viewpoint before setting on the mapview
+        map->setInitialViewpoint(newViewpoint);
+        m_insetView->setMap(map);
+        m_insetView->setAttributionTextVisible(false);
+      };
+
+      if (mapView->map()->loadStatus() == LoadStatus::Loaded)
+      {
+        setupInsetMapForMap(mapView);
+      }
+      else
+      {
+        // set up the inset map once the map is done loading
+        connect(mapView->map(), &Map::doneLoading, this, [setupInsetMapForMap, mapView](Error e)
                 {
-                  qDebug() << "Error. Main map did not load" << e.message() << e.additionalMessage();
-                  return;
-                }
+                  if (!e.isEmpty())
+                  {
+                    qDebug() << "Error. Main map did not load" << e.message() << e.additionalMessage();
+                    return;
+                  }
 
-                // create the map
-                auto map = new Map(BasemapStyle::ArcGISTopographic, m_insetView);
-
-                // set the initial viewpoint (scale = main maps's scale * scaleFactor)
-                auto initialViewpoint = mapView->map()->initialViewpoint();
-                const Viewpoint newViewpoint{
-                                             geometry_cast<Point>(initialViewpoint.targetGeometry()),
-                                             initialViewpoint.targetScale() * scaleFactor(),
-                                             initialViewpoint.rotation()};
-
-                // set the initial viewpoint before setting on the mapview
-                map->setInitialViewpoint(newViewpoint);
-                m_insetView->setAttributionTextVisible(false);
-                m_insetView->setMap(map);
-              });
+                  setupInsetMapForMap(mapView);
+                });
+      }
 
       // If Symbol has not yet been set, we provide a default symbol appropriate for MapViews.
       if (symbol() == nullptr)

--- a/uitools/common/src/OverviewMapController.cpp
+++ b/uitools/common/src/OverviewMapController.cpp
@@ -111,40 +111,22 @@ namespace Esri::ArcGISRuntime::Toolkit {
 
     if (auto sceneView = qobject_cast<SceneViewToolkit*>(m_geoView))
     {
-      // create a lambda to handle setting up the inset map and viewpoint
-      auto setupInsetMapForScene = [this](SceneViewToolkit* sceneView)
-      {
-        // create the map
-        auto map = new Map(BasemapStyle::ArcGISTopographic, m_insetView);
-        // set the initial viewpoint (scale = main scene's scale * scaleFactor)
-        const Viewpoint viewpoint = sceneView->currentViewpoint(ViewpointType::CenterAndScale);
-        const Viewpoint newViewpoint{
-                                     geometry_cast<Point>(viewpoint.targetGeometry()),
-                                     viewpoint.targetScale() * scaleFactor()};
+      // set up the inset map once the scene is done loading
+      connect(sceneView->arcGISScene(), &Scene::doneLoading, this, [this, sceneView](Error e)
+              {
+                if (!e.isEmpty())
+                {
+                  qDebug() << "Error. Main map did not load" << e.message() << e.additionalMessage();
+                  return;
+                }
 
-        // set the initial viewpoint before setting on the mapview
-        map->setInitialViewpoint(sceneView->arcGISScene()->initialViewpoint());
-        m_insetView->setMap(map);
-      };
+                setupInsetMapForScene(sceneView);
+              });
 
-      // if the map is already loaded, setup the inset map
+      // double check if the map is already loaded, setup the inset map
       if (sceneView->arcGISScene()->loadStatus() == LoadStatus::Loaded)
       {
         setupInsetMapForScene(sceneView);
-      }
-      // set up the inset map once the scene is done loading
-      else
-      {
-        connect(sceneView->arcGISScene(), &Scene::doneLoading, this, [setupInsetMapForScene = std::move(setupInsetMapForScene), sceneView](Error e)
-                {
-                  if (!e.isEmpty())
-                  {
-                    qDebug() << "Error. Main map did not load" << e.message() << e.additionalMessage();
-                    return;
-                  }
-
-                  setupInsetMapForScene(sceneView);
-                });
       }
 
       // If Symbol has not yet been set, we provide a default symbol appropriate for SceneViews.
@@ -172,42 +154,22 @@ namespace Esri::ArcGISRuntime::Toolkit {
     }
     else if (auto mapView = qobject_cast<MapViewToolkit*>(m_geoView))
     {
-      // create a lambda to handle setting up the inset map and viewpoint
-      auto setupInsetMapForMap = [this](MapViewToolkit* mapView)
-      {
-        // create the map
-        auto map = new Map(BasemapStyle::ArcGISTopographic, m_insetView);
+      // set up the inset map once the map is done loading
+      connect(mapView->map(), &Map::doneLoading, this, [this, mapView](Error e)
+              {
+                if (!e.isEmpty())
+                {
+                  qDebug() << "Error. Main map did not load" << e.message() << e.additionalMessage();
+                  return;
+                }
 
-        // set the initial viewpoint (scale = main maps's scale * scaleFactor)
-        auto initialViewpoint = mapView->map()->initialViewpoint();
-        const Viewpoint newViewpoint{
-                                     geometry_cast<Point>(initialViewpoint.targetGeometry()),
-                                     initialViewpoint.targetScale() * scaleFactor(),
-                                     initialViewpoint.rotation()};
+                setupInsetMapForMap(mapView);
+              });
 
-        // set the initial viewpoint before setting on the mapview
-        map->setInitialViewpoint(newViewpoint);
-        m_insetView->setMap(map);
-      };
-
-      // if the map is already loaded, setup the inset map
+      // double check if the map is already loaded, setup the inset map
       if (mapView->map()->loadStatus() == LoadStatus::Loaded)
       {
         setupInsetMapForMap(mapView);
-      }
-      // set up the inset map once the map is done loading
-      else
-      {
-        connect(mapView->map(), &Map::doneLoading, this, [setupInsetMapForMap = std::move(setupInsetMapForMap), mapView](Error e)
-                {
-                  if (!e.isEmpty())
-                  {
-                    qDebug() << "Error. Main map did not load" << e.message() << e.additionalMessage();
-                    return;
-                  }
-
-                  setupInsetMapForMap(mapView);
-                });
       }
 
       // If Symbol has not yet been set, we provide a default symbol appropriate for MapViews.
@@ -379,6 +341,41 @@ namespace Esri::ArcGISRuntime::Toolkit {
                        e.accept();
                      });
 #endif
+  }
+
+  // create a function to handle setting up the inset map and viewpoint
+  void OverviewMapController::setupInsetMapForMap(MapViewToolkit* mapView)
+  {
+    // create the map
+    auto map = new Map(BasemapStyle::ArcGISTopographic, m_insetView);
+
+    // set the initial viewpoint (scale = main maps's scale * scaleFactor)
+    auto initialViewpoint = mapView->map()->initialViewpoint();
+    const Viewpoint newViewpoint{
+                                 geometry_cast<Point>(initialViewpoint.targetGeometry()),
+                                 initialViewpoint.targetScale() * scaleFactor(),
+                                 initialViewpoint.rotation()};
+
+    // set the initial viewpoint before setting on the mapview
+    map->setInitialViewpoint(newViewpoint);
+    m_insetView->setMap(map);
+  }
+
+  // create a function to handle setting up the inset map and viewpoint
+  void OverviewMapController::setupInsetMapForScene(SceneViewToolkit* sceneView)
+  {
+    // create the map
+    auto map = new Map(BasemapStyle::ArcGISTopographic, m_insetView);
+    // set the initial viewpoint (scale = main scene's scale * scaleFactor)
+    // scenes shouldn't set the rotation parameter
+    const Viewpoint viewpoint = sceneView->currentViewpoint(ViewpointType::CenterAndScale);
+    const Viewpoint newViewpoint{
+                                 geometry_cast<Point>(viewpoint.targetGeometry()),
+                                 viewpoint.targetScale() * scaleFactor()};
+
+    // set the initial viewpoint before setting on the mapview
+    map->setInitialViewpoint(sceneView->arcGISScene()->initialViewpoint());
+    m_insetView->setMap(map);
   }
 
 } // Esri::ArcGISRuntime::Toolkit

--- a/uitools/common/src/OverviewMapController.cpp
+++ b/uitools/common/src/OverviewMapController.cpp
@@ -135,7 +135,7 @@ namespace Esri::ArcGISRuntime::Toolkit {
       // set up the inset map once the scene is done loading
       else
       {
-        connect(sceneView->arcGISScene(), &Scene::doneLoading, this, [setupInsetMapForScene, sceneView](Error e)
+        connect(sceneView->arcGISScene(), &Scene::doneLoading, this, [setupInsetMapForScene = std::move(setupInsetMapForScene), sceneView](Error e)
                 {
                   if (!e.isEmpty())
                   {
@@ -198,7 +198,7 @@ namespace Esri::ArcGISRuntime::Toolkit {
       // set up the inset map once the map is done loading
       else
       {
-        connect(mapView->map(), &Map::doneLoading, this, [setupInsetMapForMap, mapView](Error e)
+        connect(mapView->map(), &Map::doneLoading, this, [setupInsetMapForMap = std::move(setupInsetMapForMap), mapView](Error e)
                 {
                   if (!e.isEmpty())
                   {

--- a/uitools/common/src/OverviewMapController.cpp
+++ b/uitools/common/src/OverviewMapController.cpp
@@ -109,7 +109,6 @@ namespace Esri::ArcGISRuntime::Toolkit {
 
     m_geoView = geoView;
 
-
     if (auto sceneView = qobject_cast<SceneViewToolkit*>(m_geoView))
     {
       // create a lambda to handle setting up the inset map and viewpoint

--- a/uitools/common/src/OverviewMapController.cpp
+++ b/uitools/common/src/OverviewMapController.cpp
@@ -56,6 +56,8 @@ namespace Esri::ArcGISRuntime::Toolkit {
     m_insetView(new MapViewToolkit),
     m_reticle(new Graphic(this))
   {
+    m_insetView->setAttributionTextVisible(false);
+
     // Disable keyboard interactions, and mouse
     // interactions on devices. Keep track of mouse
     // touches.
@@ -123,7 +125,6 @@ namespace Esri::ArcGISRuntime::Toolkit {
         // set the initial viewpoint before setting on the mapview
         map->setInitialViewpoint(sceneView->arcGISScene()->initialViewpoint());
         m_insetView->setMap(map);
-        m_insetView->setAttributionTextVisible(false);
       };
 
       if (sceneView->arcGISScene()->loadStatus() == LoadStatus::Loaded)
@@ -185,7 +186,6 @@ namespace Esri::ArcGISRuntime::Toolkit {
         // set the initial viewpoint before setting on the mapview
         map->setInitialViewpoint(newViewpoint);
         m_insetView->setMap(map);
-        m_insetView->setAttributionTextVisible(false);
       };
 
       if (mapView->map()->loadStatus() == LoadStatus::Loaded)

--- a/uitools/common/src/OverviewMapController.h
+++ b/uitools/common/src/OverviewMapController.h
@@ -66,6 +66,9 @@ namespace Esri::ArcGISRuntime::Toolkit {
 
     void disableInteractions();
 
+    void setupInsetMapForMap(MapViewToolkit* mapView);
+    void setupInsetMapForScene(SceneViewToolkit* sceneView);
+
   private:
     QFuture<bool> m_setViewpointFuture;
     QFuture<bool> m_setViewpointInsetFuture;


### PR DESCRIPTION
Fixes the overview map initially displaying zoomed out

Since the inset map creation/viewpoint setting is not happening in the constructor, we need to make sure to set it in the case that the map is already loaded and if it is not yet loaded.