### PR TITLE
Calcite - slider groove typo fix

### DIFF
--- a/calcite/Calcite/SliderGroove.qml
+++ b/calcite/Calcite/SliderGroove.qml
@@ -41,7 +41,7 @@ Rectangle {
         x: groove.control.horizontal ? groove.offset * parent.width : 0
         y: groove.control.horizontal ? 0 : groove.visualProgress * parent.height
         width: groove.control.horizontal ? groove.progress * parent.width - groove.offset * parent.width : 2
-        height: groove.control.horizontal ? 2 : groove.progress * parent.height - groove.offset * parent.heigh
+        height: groove.control.horizontal ? 2 : groove.progress * parent.height - groove.offset * parent.height
         color: Calcite.brand
     }
 }


### PR DESCRIPTION
- Quick fix. This typo causes the progress track to not be correct when slider is vertical.