### PR TITLE
Calcite - Icon Integration.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "calcite/calcite-design-system"]
+	path = calcite/calcite-design-system
+	url = https://github.com/Esri/calcite-design-system.git

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ The toolkit version is declared this way because Qt's versioning system does not
 
 [Calcite style](https://github.com/Esri/arcgis-maps-sdk-toolkit-qt/tree/main/calcite) - this feature provides visual styles that enable you to create beautiful and consistent experiences using the Calcite web style for Esri on UI controls you have in your app. These styles are QML compatible and are configured by adding them to your .qml files. The styles include options for creating Light and Dark themed UI's in you app. There are over 30 styles available that can be used on Qt controls like: Button, CheckBox, Menu, RadioButton, ToolBar, and so forth. 
 
+Note: Calcite UI icons are available via the Calcite Design System submodule.
+
 ## Resources
 
 * [ArcGIS Maps SDK for Qt](https://developers.arcgis.com/qt/)
@@ -61,7 +63,7 @@ Find a bug or want to request a new feature?  Please let us know by [submitting 
 
 # Licensing
 
-Copyright 2019-2022 Esri
+Copyright 2019-2025 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/calcite/README.md
+++ b/calcite/README.md
@@ -130,9 +130,9 @@ In the [demo](./demo/) folder, there is a Qt demo application project (calcite_t
 
 The Calcite Design System icons are included as a Git submodule.
 
-- Source (submodule): `calcite-design-system/packages/ui-icons`
+- Source (submodule): `calcite-design-system/packages/ui-icons/icons/`
 
-Each icon is available in multiple sizes: 16, 24, and 32 pixels. The Calcite icon set contains over 1000 icons. Browse the full catalog here: https://developers.arcgis.com/calcite-design-system/icons/
+Each icon is an SVG and available in multiple sizes: 16, 24, and 32 pixels. The Calcite icon set contains over 1000 icons. Browse the full catalog [here](https://developers.arcgis.com/calcite-design-system/icons/).
 
 ### Using icons in QML
 

--- a/calcite/README.md
+++ b/calcite/README.md
@@ -125,3 +125,47 @@ For further details see [Calcite Web TypeFaces](https://esri.github.io/calcite-w
 ## Demo app
 
 In the [demo](./demo/) folder, there is a Qt demo application project (calcite_test.pro) that showcases many of the Qt toolkit Calcite components being used.
+
+## Calcite Icons
+
+The Calcite Design System icons are included as a Git submodule.
+
+- Source (submodule): `calcite-design-system/packages/ui-icons`
+
+Each icon is available in multiple sizes: 16, 24, and 32 pixels. The Calcite icon set contains over 1000 icons. Browse the full catalog here: https://developers.arcgis.com/calcite-design-system/icons/
+
+### Using icons in QML
+
+Option A: via resource file (recommended)
+```qml
+import QtQuick
+
+Image {
+  source: "qrc:/calcite/Calcite/images/ui-icons/plus-16.svg"
+}
+```
+
+Option B: file path (when not using resources)
+```qml
+import QtQuick
+
+Image {
+  source: Qt.resolvedUrl("../calcite/Calcite/images/ui-icons/plus-24.svg")
+}
+```
+Ensure the path is packaged in your app if you are not using `qrc` resources.
+
+### Initialize/update the icons submodule
+
+If you cloned this repo without submodules, or are updating to the latest icons:
+
+```zsh
+# From repository root
+git submodule update --init --recursive
+
+# Optional: stay in sync with upstream
+git submodule sync --recursive
+git submodule update --recursive --remote
+```
+
+Rebuild your project so the `.qrc` picks up icon additions.

--- a/calcite/README.md
+++ b/calcite/README.md
@@ -157,15 +157,11 @@ Ensure the path is packaged in your app if you are not using `qrc` resources.
 
 ### Initialize/update the icons submodule
 
-If you cloned this repo without submodules, or are updating to the latest icons:
+If you cloned this repo without submodules:
 
 ```zsh
 # From repository root
 git submodule update --init --recursive
-
-# Optional: stay in sync with upstream
-git submodule sync --recursive
-git submodule update --recursive --remote
 ```
 
 Rebuild your project so the `.qrc` picks up icon additions.

--- a/calcite/demo/Resources/calcite-icons.qrc
+++ b/calcite/demo/Resources/calcite-icons.qrc
@@ -1,14 +1,11 @@
 <RCC>
     <qresource prefix="/calcite/icons">
-        <!-- Navigation Icons -->
         <file alias="chevron-left-24.svg">../../calcite-design-system/packages/ui-icons/icons/chevron-left-24.svg</file>
         <file alias="chevron-right-24.svg">../../calcite-design-system/packages/ui-icons/icons/chevron-right-24.svg</file>
         <file alias="chevron-up-24.svg">../../calcite-design-system/packages/ui-icons/icons/chevron-up-24.svg</file>
         <file alias="chevron-down-24.svg">../../calcite-design-system/packages/ui-icons/icons/chevron-down-24.svg</file>
         <file alias="arrow-left-24.svg">../../calcite-design-system/packages/ui-icons/icons/arrow-left-24.svg</file>
         <file alias="arrow-right-24.svg">../../calcite-design-system/packages/ui-icons/icons/arrow-right-24.svg</file>
-
-        <!-- Action Icons -->
         <file alias="plus-24.svg">../../calcite-design-system/packages/ui-icons/icons/plus-24.svg</file>
         <file alias="minus-24.svg">../../calcite-design-system/packages/ui-icons/icons/minus-24.svg</file>
         <file alias="x-24.svg">../../calcite-design-system/packages/ui-icons/icons/x-24.svg</file>
@@ -17,21 +14,15 @@
         <file alias="trash-24.svg">../../calcite-design-system/packages/ui-icons/icons/trash-24.svg</file>
         <file alias="pencil-24.svg">../../calcite-design-system/packages/ui-icons/icons/pencil-24.svg</file>
         <file alias="copy-24.svg">../../calcite-design-system/packages/ui-icons/icons/copy-24.svg</file>
-
-        <!-- UI Icons -->
         <file alias="search-24.svg">../../calcite-design-system/packages/ui-icons/icons/search-24.svg</file>
         <file alias="gear-24.svg">../../calcite-design-system/packages/ui-icons/icons/gear-24.svg</file>
         <file alias="information-24.svg">../../calcite-design-system/packages/ui-icons/icons/information-24.svg</file>
         <file alias="question-24.svg">../../calcite-design-system/packages/ui-icons/icons/question-24.svg</file>
         <file alias="ellipsis-24.svg">../../calcite-design-system/packages/ui-icons/icons/ellipsis-24.svg</file>
         <file alias="home-24.svg">../../calcite-design-system/packages/ui-icons/icons/home-24.svg</file>
-
-        <!-- Map/GIS Icons -->
         <file alias="map-24.svg">../../calcite-design-system/packages/ui-icons/icons/map-24.svg</file>
         <file alias="layer-24.svg">../../calcite-design-system/packages/ui-icons/icons/layer-24.svg</file>
         <file alias="pin-24.svg">../../calcite-design-system/packages/ui-icons/icons/pin-24.svg</file>
-
-        <!-- File Icons -->
         <file alias="folder-24.svg">../../calcite-design-system/packages/ui-icons/icons/folder-24.svg</file>
         <file alias="web-24.svg">../../calcite-design-system/packages/ui-icons/icons/web-24.svg</file>
     </qresource>

--- a/calcite/demo/Resources/calcite-icons.qrc
+++ b/calcite/demo/Resources/calcite-icons.qrc
@@ -1,0 +1,38 @@
+<RCC>
+    <qresource prefix="/calcite/icons">
+        <!-- Navigation Icons -->
+        <file alias="chevron-left-24.svg">../../calcite-design-system/packages/ui-icons/icons/chevron-left-24.svg</file>
+        <file alias="chevron-right-24.svg">../../calcite-design-system/packages/ui-icons/icons/chevron-right-24.svg</file>
+        <file alias="chevron-up-24.svg">../../calcite-design-system/packages/ui-icons/icons/chevron-up-24.svg</file>
+        <file alias="chevron-down-24.svg">../../calcite-design-system/packages/ui-icons/icons/chevron-down-24.svg</file>
+        <file alias="arrow-left-24.svg">../../calcite-design-system/packages/ui-icons/icons/arrow-left-24.svg</file>
+        <file alias="arrow-right-24.svg">../../calcite-design-system/packages/ui-icons/icons/arrow-right-24.svg</file>
+
+        <!-- Action Icons -->
+        <file alias="plus-24.svg">../../calcite-design-system/packages/ui-icons/icons/plus-24.svg</file>
+        <file alias="minus-24.svg">../../calcite-design-system/packages/ui-icons/icons/minus-24.svg</file>
+        <file alias="x-24.svg">../../calcite-design-system/packages/ui-icons/icons/x-24.svg</file>
+        <file alias="check-24.svg">../../calcite-design-system/packages/ui-icons/icons/check-24.svg</file>
+        <file alias="save-24.svg">../../calcite-design-system/packages/ui-icons/icons/save-24.svg</file>
+        <file alias="trash-24.svg">../../calcite-design-system/packages/ui-icons/icons/trash-24.svg</file>
+        <file alias="pencil-24.svg">../../calcite-design-system/packages/ui-icons/icons/pencil-24.svg</file>
+        <file alias="copy-24.svg">../../calcite-design-system/packages/ui-icons/icons/copy-24.svg</file>
+
+        <!-- UI Icons -->
+        <file alias="search-24.svg">../../calcite-design-system/packages/ui-icons/icons/search-24.svg</file>
+        <file alias="gear-24.svg">../../calcite-design-system/packages/ui-icons/icons/gear-24.svg</file>
+        <file alias="information-24.svg">../../calcite-design-system/packages/ui-icons/icons/information-24.svg</file>
+        <file alias="question-24.svg">../../calcite-design-system/packages/ui-icons/icons/question-24.svg</file>
+        <file alias="ellipsis-24.svg">../../calcite-design-system/packages/ui-icons/icons/ellipsis-24.svg</file>
+        <file alias="home-24.svg">../../calcite-design-system/packages/ui-icons/icons/home-24.svg</file>
+
+        <!-- Map/GIS Icons -->
+        <file alias="map-24.svg">../../calcite-design-system/packages/ui-icons/icons/map-24.svg</file>
+        <file alias="layer-24.svg">../../calcite-design-system/packages/ui-icons/icons/layer-24.svg</file>
+        <file alias="pin-24.svg">../../calcite-design-system/packages/ui-icons/icons/pin-24.svg</file>
+
+        <!-- File Icons -->
+        <file alias="folder-24.svg">../../calcite-design-system/packages/ui-icons/icons/folder-24.svg</file>
+        <file alias="web-24.svg">../../calcite-design-system/packages/ui-icons/icons/web-24.svg</file>
+    </qresource>
+</RCC>

--- a/calcite/demo/calcite_test.pro
+++ b/calcite/demo/calcite_test.pro
@@ -63,7 +63,7 @@ exists($$PWD/../calcite-design-system/packages/ui-icons/icons) {
     RESOURCES += Resources/calcite-icons.qrc
     message("Calcite icons submodule detected - including icon resources")
 } else {
-    warning("Calcite icons submodule not initialized. Run: git submodule update --init --recursive")
+    message("Calcite icons submodule not initialized. Run: git submodule update --init --recursive")
 }
 
 OTHER_FILES += \

--- a/calcite/demo/calcite_test.pro
+++ b/calcite/demo/calcite_test.pro
@@ -58,6 +58,14 @@ RESOURCES += \
     Resources/Resources.qrc \
     $$absolute_path($$PWD/../Calcite/calcite.qrc)
 
+# Optional: Calcite Icons from submodule (only if submodule is initialized)
+exists($$PWD/../calcite-design-system/packages/ui-icons/icons) {
+    RESOURCES += Resources/calcite-icons.qrc
+    message("Calcite icons submodule detected - including icon resources")
+} else {
+    warning("Calcite icons submodule not initialized. Run: git submodule update --init --recursive")
+}
+
 OTHER_FILES += \
     wizard.xml \
     wizard.png

--- a/calcite/demo/qml/IconShowcase.qml
+++ b/calcite/demo/qml/IconShowcase.qml
@@ -22,7 +22,9 @@ import Calcite as C
 Pane {
     id: root
 
-    property var icons: [
+    property bool submoduleInitialized
+
+    property var icons: !root.submoduleInitialized? [] :[
         // Arrows
         { name: "chevron-left", path: "qrc:/calcite/icons/chevron-left-24.svg", category: "Arrows" },
         { name: "chevron-right", path: "qrc:/calcite/icons/chevron-right-24.svg", category: "Arrows" },
@@ -63,14 +65,14 @@ Pane {
         spacing: 10
 
         Label {
-            text: "Calcite Icons Showcase"
+            text: qsTr("Calcite Icons Showcase")
             font.pixelSize: 20
             font.bold: true
             Layout.alignment: Qt.AlignHCenter
         }
 
         Label {
-            text: "Sample Icons from Calcite Design System"
+            text: qsTr("Sample Icons from the Calcite Design System")
             font.pixelSize: 12
             opacity: 0.7
             Layout.alignment: Qt.AlignHCenter
@@ -134,8 +136,8 @@ Pane {
             spacing: 10
 
             Button {
-                text: "View All Icons Online"
-                icon.source: "qrc:/calcite/icons/web-24.svg"
+                text: qsTr("View All Icons Online")
+                icon.source: root.submoduleInitialized? "qrc:/calcite/icons/web-24.svg" : ""
                 icon.color: "#ffffff"
                 Layout.fillWidth: true
                 onClicked: {
@@ -144,8 +146,8 @@ Pane {
             }
 
             Button {
-                text: "Open Icons Folder"
-                icon.source: "qrc:/calcite/icons/folder-24.svg"
+                text: qsTr("Open Icons Folder")
+                icon.source: root.submoduleInitialized? "qrc:/calcite/icons/folder-24.svg" : ""
                 icon.color: "#ffffff"
                 Layout.fillWidth: true
                 onClicked: {
@@ -165,7 +167,7 @@ Pane {
         }
 
         Label {
-            text: "23 sample icons shown • 1,000+ available in submodule"
+            text: qsTr("23 sample icons shown • 1,000+ available in submodule")
             font.pixelSize: 10
             opacity: 0.5
             Layout.alignment: Qt.AlignHCenter

--- a/calcite/demo/qml/IconShowcase.qml
+++ b/calcite/demo/qml/IconShowcase.qml
@@ -167,7 +167,7 @@ Pane {
         }
 
         Label {
-            text: qsTr("23 sample icons shown • 1,000+ available in submodule")
+            text: qsTr("23 sample icons shown • 1,000+ icons available in submodule")
             font.pixelSize: 10
             opacity: 0.5
             Layout.alignment: Qt.AlignHCenter

--- a/calcite/demo/qml/IconShowcase.qml
+++ b/calcite/demo/qml/IconShowcase.qml
@@ -1,0 +1,175 @@
+/*******************************************************************************
+ *  Copyright 2012-2025 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Calcite
+import Calcite as C
+
+Pane {
+    id: root
+
+    property var icons: [
+        // Arrows
+        { name: "chevron-left", path: "qrc:/calcite/icons/chevron-left-24.svg", category: "Arrows" },
+        { name: "chevron-right", path: "qrc:/calcite/icons/chevron-right-24.svg", category: "Arrows" },
+        { name: "chevron-up", path: "qrc:/calcite/icons/chevron-up-24.svg", category: "Arrows" },
+        { name: "chevron-down", path: "qrc:/calcite/icons/chevron-down-24.svg", category: "Arrows" },
+        { name: "arrow-left", path: "qrc:/calcite/icons/arrow-left-24.svg", category: "Arrows" },
+        { name: "arrow-right", path: "qrc:/calcite/icons/arrow-right-24.svg", category: "Arrows" },
+
+        // Generic
+        { name: "save", path: "qrc:/calcite/icons/save-24.svg", category: "Generic" },
+        { name: "ellipsis", path: "qrc:/calcite/icons/ellipsis-24.svg", category: "Generic" },
+        { name: "home", path: "qrc:/calcite/icons/home-24.svg", category: "Generic" },
+
+        // Objects
+        { name: "trash", path: "qrc:/calcite/icons/trash-24.svg", category: "Objects" },
+        { name: "pencil", path: "qrc:/calcite/icons/pencil-24.svg", category: "Objects" },
+        { name: "copy", path: "qrc:/calcite/icons/copy-24.svg", category: "Objects" },
+        { name: "gear", path: "qrc:/calcite/icons/gear-24.svg", category: "Objects" },
+
+        // Symbols
+        { name: "plus", path: "qrc:/calcite/icons/plus-24.svg", category: "Symbols" },
+        { name: "minus", path: "qrc:/calcite/icons/minus-24.svg", category: "Symbols" },
+        { name: "x", path: "qrc:/calcite/icons/x-24.svg", category: "Symbols" },
+        { name: "check", path: "qrc:/calcite/icons/check-24.svg", category: "Symbols" },
+        { name: "search", path: "qrc:/calcite/icons/search-24.svg", category: "Symbols" },
+        { name: "information", path: "qrc:/calcite/icons/information-24.svg", category: "Symbols" },
+        { name: "question", path: "qrc:/calcite/icons/question-24.svg", category: "Symbols" },
+
+        // GIS/Layers
+        { name: "map", path: "qrc:/calcite/icons/map-24.svg", category: "GIS" },
+        { name: "pin", path: "qrc:/calcite/icons/pin-24.svg", category: "GIS" },
+        { name: "layer", path: "qrc:/calcite/icons/layer-24.svg", category: "Layers" }
+
+    ]
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 10
+
+        Label {
+            text: "Calcite Icons Showcase"
+            font.pixelSize: 20
+            font.bold: true
+            Layout.alignment: Qt.AlignHCenter
+        }
+
+        Label {
+            text: "Sample Icons from Calcite Design System"
+            font.pixelSize: 12
+            opacity: 0.7
+            Layout.alignment: Qt.AlignHCenter
+        }
+
+        ScrollView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            clip: true
+
+            GridLayout {
+                columns: 4
+                rowSpacing: 15
+                columnSpacing: 15
+
+                Repeater {
+                    model: root.icons
+
+                    Pane {
+                        Layout.preferredWidth: 120
+                        Layout.preferredHeight: 100
+
+                        ColumnLayout {
+                            anchors.centerIn: parent
+                            spacing: 8
+
+                            Button {
+                                icon.source: modelData.path
+                                icon.width: 32
+                                icon.height: 32
+                                icon.color: C.Calcite.theme === C.Calcite.Dark ? "#ffffff" : "#151515"
+                                flat: true
+                                Layout.alignment: Qt.AlignHCenter
+                            }
+
+                            Label {
+                                text: modelData.name
+                                font.pixelSize: 10
+                                horizontalAlignment: Text.AlignHCenter
+                                Layout.alignment: Qt.AlignHCenter
+                                Layout.preferredWidth: parent.width
+                                wrapMode: Text.WordWrap
+                            }
+
+                            Label {
+                                text: modelData.category
+                                font.pixelSize: 8
+                                opacity: 0.6
+                                horizontalAlignment: Text.AlignHCenter
+                                Layout.alignment: Qt.AlignHCenter
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        RowLayout {
+            Layout.alignment: Qt.AlignHCenter
+            Layout.preferredWidth: parent.width * 0.8
+            spacing: 10
+
+            Button {
+                text: "View All Icons Online"
+                icon.source: "qrc:/calcite/icons/web-24.svg"
+                icon.color: "#ffffff"
+                Layout.fillWidth: true
+                onClicked: {
+                    Qt.openUrlExternally("https://developers.arcgis.com/calcite-design-system/icons/")
+                }
+            }
+
+            Button {
+                text: "Open Icons Folder"
+                icon.source: "qrc:/calcite/icons/folder-24.svg"
+                icon.color: "#ffffff"
+                Layout.fillWidth: true
+                onClicked: {
+                    var appPath = Qt.application.arguments[0].replace(/\\/g, "/")
+                    var appDir = appPath.substring(0, appPath.lastIndexOf("/"))
+
+                    var parts = appDir.split("/")
+                    parts = parts.slice(0, -6)
+                    var basePath = parts.join("/")
+                    var iconsPath = basePath + "/calcite-design-system/packages/ui-icons/icons/"
+
+                    var fileUrl = encodeURI("file://" + iconsPath)
+                    Qt.openUrlExternally(fileUrl)
+                }
+            }
+
+        }
+
+        Label {
+            text: "23 sample icons shown • 1,000+ available in submodule"
+            font.pixelSize: 10
+            opacity: 0.5
+            Layout.alignment: Qt.AlignHCenter
+            horizontalAlignment: Text.AlignHCenter
+        }
+    }
+}

--- a/calcite/demo/qml/main.qml
+++ b/calcite/demo/qml/main.qml
@@ -37,6 +37,13 @@ ApplicationWindow {
         //Calcite.theme = Calcite.Dark;
     }
 
+    // Check if Calcite icons submodule is initialized
+    property bool calciteIconsAvailable: {
+        // Check if icon resources are available
+        var testPath = "qrc:/calcite/icons/check-24.svg"
+        return Qt.resolvedUrl(testPath).toString().length > 0
+    }
+
     // add a mapView component
     MapView {
         id: mapView
@@ -111,6 +118,36 @@ ApplicationWindow {
                         text: modelData
                     }
                 }
+            }
+        }
+
+        Dialog {
+            id: iconShowcaseDialog
+            anchors.centerIn: parent
+            standardButtons: Dialog.Close
+            implicitWidth: 600
+            implicitHeight: 500
+
+            // Only available if submodule is initialized
+            property bool iconsAvailable: {
+                // Try to load an icon to check if submodule is initialized
+                var testImage = Qt.createQmlObject('import QtQuick; Image { source: "qrc:/calcite/icons/check-24.svg" }', iconShowcaseDialog, "testImage")
+                var available = testImage.status === Image.Ready || testImage.status === Image.Loading
+                testImage.destroy()
+                return available
+            }
+
+            IconShowcase {
+                anchors.fill: parent
+                visible: iconShowcaseDialog.iconsAvailable
+            }
+
+            Label {
+                anchors.centerIn: parent
+                visible: !iconShowcaseDialog.iconsAvailable
+                text: "Icons not available.\n\nInitialize the submodule:\ngit submodule update --init --recursive"
+                horizontalAlignment: Text.AlignHCenter
+                font.pixelSize: 14
             }
         }
 
@@ -291,6 +328,21 @@ ApplicationWindow {
                     clip: true
                     indeterminate: true
                 }
+            }
+        }
+
+        // Icon Showcase Button - Bottom Left
+        Button {
+            anchors {
+                left: parent.left
+                bottom: parent.attributionTop
+                margins: 10
+            }
+            text: "Calcite Icons"
+            visible: appWindow.calciteIconsAvailable
+            enabled: appWindow.calciteIconsAvailable
+            onPressed: {
+                iconShowcaseDialog.open()
             }
         }
 

--- a/calcite/demo/qml/main.qml
+++ b/calcite/demo/qml/main.qml
@@ -32,11 +32,6 @@ ApplicationWindow {
         mapView: mapView
     }
 
-    Component.onCompleted: {
-
-        //Calcite.theme = Calcite.Dark;
-    }
-
     // Check if Calcite icons submodule is initialized
     property bool calciteIconsAvailable: {
         // Check if icon resources are available
@@ -140,12 +135,13 @@ ApplicationWindow {
             IconShowcase {
                 anchors.fill: parent
                 visible: iconShowcaseDialog.iconsAvailable
+                submoduleInitialized: iconShowcaseDialog.iconsAvailable
             }
 
             Label {
                 anchors.centerIn: parent
                 visible: !iconShowcaseDialog.iconsAvailable
-                text: "Icons not available.\n\nInitialize the submodule:\ngit submodule update --init --recursive"
+                text: "Icons not available.\n\nInitialize the submodule and rebuild:\ngit submodule update --init --recursive"
                 horizontalAlignment: Text.AlignHCenter
                 font.pixelSize: 14
             }

--- a/calcite/demo/qml/qml.qrc
+++ b/calcite/demo/qml/qml.qrc
@@ -1,5 +1,6 @@
 <RCC>
     <qresource prefix="/qml">
         <file>main.qml</file>
+        <file>IconShowcase.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
This PR contains the following changes:

- Added calcite-design-system repo as a submodule for the icons.
- Updated Readme files
- Created calcite-icons.qrc which references icons from the submodule. This will be included in the calcite_test build only if the submodule folder is found. 
- Updated calcite_test project to display/demo calcite icon usage. 
    - main.qml: added dialog and button to open icons showcase menu
    - IconShowcase.qml: newly added qml file that displays some icons.