### PR TITLE
Calcite Demo - Scale fixes for mobile, Hide open folder button for andriod/ios.

### DIFF
--- a/calcite/demo/calcite_test.pro
+++ b/calcite/demo/calcite_test.pro
@@ -82,6 +82,8 @@ macx {
 
 ios {
     include (iOS/iOS.pri)
+    QT -= multimedia
+    DEFINES += QT_NO_MULTIMEDIA_WIDGETS
 }
 
 android {

--- a/calcite/demo/calcite_test.pro
+++ b/calcite/demo/calcite_test.pro
@@ -82,8 +82,33 @@ macx {
 
 ios {
     include (iOS/iOS.pri)
-    QT -= multimedia
-    DEFINES += QT_NO_MULTIMEDIA_WIDGETS
+    PLATFORM = "iOS"
+
+    # workaround for https://bugreports.qt.io/browse/QTBUG-129651
+    # ArcGIS Maps SDK for Qt adds 'QMAKE_RPATHDIR = @executable_path/Frameworks'
+    # and ffmpeg frameworks have embedded '@rpath/Frameworks' path.
+    # so in order for them to be found, we need to add @executable_path to the
+    # search path.
+    FFMPEG_LIB_DIR = $$absolute_path($$replace(QMAKE_QMAKE, "qmake6", "../../ios/lib/ffmpeg"))
+    FFMPEG_LIB_DIR = $$absolute_path($$replace(FFMPEG_LIB_DIR, "qmake", "../../ios/lib/ffmpeg"))
+    QMAKE_LFLAGS += -F$${FFMPEG_LIB_DIR} -Wl,-rpath,@executable_path
+    versionAtLeast(QT_VERSION, 6.8.3) {
+      FRAMEWORK = "xcframework"
+    } else {
+      FRAMEWORK = "framework"
+    }
+    LIBS += -framework libavcodec \
+            -framework libavformat \
+            -framework libavutil \
+            -framework libswresample \
+            -framework libswscale
+    ffmpeg.files = $${FFMPEG_LIB_DIR}/libavcodec.$${FRAMEWORK} \
+                   $${FFMPEG_LIB_DIR}/libavformat.$${FRAMEWORK} \
+                   $${FFMPEG_LIB_DIR}/libavutil.$${FRAMEWORK} \
+                   $${FFMPEG_LIB_DIR}/libswresample.$${FRAMEWORK} \
+                   $${FFMPEG_LIB_DIR}/libswscale.$${FRAMEWORK}
+    ffmpeg.path = Frameworks
+    QMAKE_BUNDLE_DATA += ffmpeg
 }
 
 android {

--- a/calcite/demo/qml/IconShowcase.qml
+++ b/calcite/demo/qml/IconShowcase.qml
@@ -24,41 +24,45 @@ Pane {
 
     property bool submoduleInitialized
 
+    property bool canOpenLocalFolders: Qt.platform.os === "windows" ||
+                                       Qt.platform.os === "osx" ||
+                                       Qt.platform.os === "linux"
+
     property var icons: !root.submoduleInitialized? [] :[
-        // Arrows
-        { name: "chevron-left", path: "qrc:/calcite/icons/chevron-left-24.svg", category: "Arrows" },
-        { name: "chevron-right", path: "qrc:/calcite/icons/chevron-right-24.svg", category: "Arrows" },
-        { name: "chevron-up", path: "qrc:/calcite/icons/chevron-up-24.svg", category: "Arrows" },
-        { name: "chevron-down", path: "qrc:/calcite/icons/chevron-down-24.svg", category: "Arrows" },
-        { name: "arrow-left", path: "qrc:/calcite/icons/arrow-left-24.svg", category: "Arrows" },
-        { name: "arrow-right", path: "qrc:/calcite/icons/arrow-right-24.svg", category: "Arrows" },
+                                                        // Arrows
+                                                        { name: "chevron-left", path: "qrc:/calcite/icons/chevron-left-24.svg", category: "Arrows" },
+                                                        { name: "chevron-right", path: "qrc:/calcite/icons/chevron-right-24.svg", category: "Arrows" },
+                                                        { name: "chevron-up", path: "qrc:/calcite/icons/chevron-up-24.svg", category: "Arrows" },
+                                                        { name: "chevron-down", path: "qrc:/calcite/icons/chevron-down-24.svg", category: "Arrows" },
+                                                        { name: "arrow-left", path: "qrc:/calcite/icons/arrow-left-24.svg", category: "Arrows" },
+                                                        { name: "arrow-right", path: "qrc:/calcite/icons/arrow-right-24.svg", category: "Arrows" },
 
-        // Generic
-        { name: "save", path: "qrc:/calcite/icons/save-24.svg", category: "Generic" },
-        { name: "ellipsis", path: "qrc:/calcite/icons/ellipsis-24.svg", category: "Generic" },
-        { name: "home", path: "qrc:/calcite/icons/home-24.svg", category: "Generic" },
+                                                        // Generic
+                                                        { name: "save", path: "qrc:/calcite/icons/save-24.svg", category: "Generic" },
+                                                        { name: "ellipsis", path: "qrc:/calcite/icons/ellipsis-24.svg", category: "Generic" },
+                                                        { name: "home", path: "qrc:/calcite/icons/home-24.svg", category: "Generic" },
 
-        // Objects
-        { name: "trash", path: "qrc:/calcite/icons/trash-24.svg", category: "Objects" },
-        { name: "pencil", path: "qrc:/calcite/icons/pencil-24.svg", category: "Objects" },
-        { name: "copy", path: "qrc:/calcite/icons/copy-24.svg", category: "Objects" },
-        { name: "gear", path: "qrc:/calcite/icons/gear-24.svg", category: "Objects" },
+                                                        // Objects
+                                                        { name: "trash", path: "qrc:/calcite/icons/trash-24.svg", category: "Objects" },
+                                                        { name: "pencil", path: "qrc:/calcite/icons/pencil-24.svg", category: "Objects" },
+                                                        { name: "copy", path: "qrc:/calcite/icons/copy-24.svg", category: "Objects" },
+                                                        { name: "gear", path: "qrc:/calcite/icons/gear-24.svg", category: "Objects" },
 
-        // Symbols
-        { name: "plus", path: "qrc:/calcite/icons/plus-24.svg", category: "Symbols" },
-        { name: "minus", path: "qrc:/calcite/icons/minus-24.svg", category: "Symbols" },
-        { name: "x", path: "qrc:/calcite/icons/x-24.svg", category: "Symbols" },
-        { name: "check", path: "qrc:/calcite/icons/check-24.svg", category: "Symbols" },
-        { name: "search", path: "qrc:/calcite/icons/search-24.svg", category: "Symbols" },
-        { name: "information", path: "qrc:/calcite/icons/information-24.svg", category: "Symbols" },
-        { name: "question", path: "qrc:/calcite/icons/question-24.svg", category: "Symbols" },
+                                                        // Symbols
+                                                        { name: "plus", path: "qrc:/calcite/icons/plus-24.svg", category: "Symbols" },
+                                                        { name: "minus", path: "qrc:/calcite/icons/minus-24.svg", category: "Symbols" },
+                                                        { name: "x", path: "qrc:/calcite/icons/x-24.svg", category: "Symbols" },
+                                                        { name: "check", path: "qrc:/calcite/icons/check-24.svg", category: "Symbols" },
+                                                        { name: "search", path: "qrc:/calcite/icons/search-24.svg", category: "Symbols" },
+                                                        { name: "information", path: "qrc:/calcite/icons/information-24.svg", category: "Symbols" },
+                                                        { name: "question", path: "qrc:/calcite/icons/question-24.svg", category: "Symbols" },
 
-        // GIS/Layers
-        { name: "map", path: "qrc:/calcite/icons/map-24.svg", category: "GIS" },
-        { name: "pin", path: "qrc:/calcite/icons/pin-24.svg", category: "GIS" },
-        { name: "layer", path: "qrc:/calcite/icons/layer-24.svg", category: "Layers" }
+                                                        // GIS/Layers
+                                                        { name: "map", path: "qrc:/calcite/icons/map-24.svg", category: "GIS" },
+                                                        { name: "pin", path: "qrc:/calcite/icons/pin-24.svg", category: "GIS" },
+                                                        { name: "layer", path: "qrc:/calcite/icons/layer-24.svg", category: "Layers" }
 
-    ]
+                                                    ]
 
     ColumnLayout {
         anchors.fill: parent
@@ -79,12 +83,23 @@ Pane {
         }
 
         ScrollView {
+            id: scrollView
             Layout.fillWidth: true
             Layout.fillHeight: true
             clip: true
+            ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
 
             GridLayout {
-                columns: 4
+                id: iconGrid
+                width: scrollView.availableWidth
+                // Calculate columns based on actual available width
+                columns: {
+                    const itemWidth = 120
+                    const spacing = 15
+                    const availableWidth = iconGrid.width
+                    const cols = Math.floor(availableWidth / itemWidth)
+                    return Math.max(1, Math.min(cols, 4))
+                }
                 rowSpacing: 15
                 columnSpacing: 15
 
@@ -150,16 +165,29 @@ Pane {
                 icon.source: root.submoduleInitialized? "qrc:/calcite/icons/folder-24.svg" : ""
                 icon.color: "#ffffff"
                 Layout.fillWidth: true
+                visible: root.canOpenLocalFolders
                 onClicked: {
                     var appPath = Qt.application.arguments[0].replace(/\\/g, "/")
-                    var appDir = appPath.substring(0, appPath.lastIndexOf("/"))
+                    var iconsPath
+                    var fileUrl
 
-                    var parts = appDir.split("/")
-                    parts = parts.slice(0, -6)
-                    var basePath = parts.join("/")
-                    var iconsPath = basePath + "/calcite-design-system/packages/ui-icons/icons/"
-
-                    var fileUrl = encodeURI("file://" + iconsPath)
+                    if (Qt.platform.os === "windows") {
+                        var calciteIndex = appPath.lastIndexOf("/calcite/")
+                        if (calciteIndex === -1) {
+                            console.log("Could not find calcite folder in path")
+                            return
+                        }
+                        var calcitePath = appPath.substring(0, calciteIndex + 8)
+                        iconsPath = calcitePath + "/calcite-design-system/packages/ui-icons/icons/"
+                        fileUrl = "file:///" + iconsPath
+                    } else {
+                        var appDir = appPath.substring(0, appPath.lastIndexOf("/"))
+                        var parts = appDir.split("/")
+                        parts = parts.slice(0, -6)
+                        var basePath = parts.join("/")
+                        iconsPath = basePath + "/calcite-design-system/packages/ui-icons/icons/"
+                        fileUrl = encodeURI("file://" + iconsPath)
+                    }
                     Qt.openUrlExternally(fileUrl)
                 }
             }

--- a/calcite/demo/qml/main.qml
+++ b/calcite/demo/qml/main.qml
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  *  Copyright 2012-2021 Esri
  *
@@ -39,334 +38,405 @@ ApplicationWindow {
         return Qt.resolvedUrl(testPath).toString().length > 0
     }
 
-    // add a mapView component
-    MapView {
-        id: mapView
-        anchors.fill: parent
-        // set focus to enable keyboard navigation
-        focus: true
-
-
-        Pane {
-            anchors {
-                right: parent.right
-                top: parent.top
-            }
-            ColumnLayout {
-                Switch {
-                    id: themeSwitch
-                    text: checked ? "Dark Mode" : "Light Mode"
-                    Layout.alignment: Qt.AlignRight
-                    enabled: !C.Calcite.useSystemTheme
-                    property var selectedTheme: themeSwitch.checked ? C.Calcite.Dark : C.Calcite.Light
-
-                    Binding {
-                        target: C.Calcite
-                        property: "theme"
-                        value: themeSwitch.enabled ? themeSwitch.selectedTheme : Application.styleHints.colorScheme
-                    }
-
-
-                }
-                CheckBox {
-                    id: enabler
-                    text: "Enabled"
-                    checked: true
-                }
-                CheckBox {
-                    id: useSystemThemeCheckBox
-                    text: "Use System Theme"
-                    checked: true
-
-                    Binding {
-                        target: C.Calcite
-                        property: "useSystemTheme"
-                        value: useSystemThemeCheckBox.checked
-                    }
-                    Binding {
-                        target: C.Calcite
-                        property: "theme"
-                        value: useSystemThemeCheckBox.checked ? Application.styleHints.colorScheme :
-                                                                themeSwitch.selectedTheme
-                    }
-                }
-            }
+    readonly property int topInset: Qt.platform.os === "android" ? 40 : 0
+    readonly property int bottomInset: Qt.platform.os === "android" ? 30 : 0
+    Item {
+        id: safeArea
+        anchors {
+            fill: parent
+            topMargin: topInset
+            bottomMargin: bottomInset
         }
+        // add a mapView component
+        MapView {
+            id: mapView
+            anchors.fill: parent
+            // set focus to enable keyboard navigation
+            focus: true
 
-        Dialog {
-            id: dialog
-            title: "Dialog"
-            anchors.centerIn: parent
-            standardButtons: Dialog.Ok | Dialog.Cancel | Dialog.Help
-            implicitWidth: 400
-            implicitHeight: 300
             Pane {
-                anchors.fill: parent
-                contentItem: ListView {
-                    clip: true
-                    anchors.fill: parent
-                    model: ["Option 1", "Option 2", "Option 3", "Option 4", "Option 5", "Option 6"]
-                    ScrollBar.vertical: ScrollBar {}
-                    delegate: RadioDelegate {
-                        anchors.left: parent.left
-                        anchors.right: parent.right
-                        text: modelData
-                    }
+                id: topRightPane
+                anchors {
+                    right: parent.right
+                    top: parent.top
+                    margins: 5
                 }
-            }
-        }
+                z: 100
 
-        Dialog {
-            id: iconShowcaseDialog
-            anchors.centerIn: parent
-            standardButtons: Dialog.Close
-            implicitWidth: 600
-            implicitHeight: 500
+                // Scale to fit smaller screens
+                implicitWidth: themeLayout.implicitWidth + leftPadding + rightPadding
+                implicitHeight: themeLayout.implicitHeight + topPadding + bottomPadding
+                scale: Math.min(1.0,
+                                Math.min(mapView.width * 0.3 / Math.max(implicitWidth, 1),
+                                         mapView.height * 0.3 / Math.max(implicitHeight, 1)))
+                transformOrigin: Item.TopRight
 
-            // Only available if submodule is initialized
-            property bool iconsAvailable: {
-                // Try to load an icon to check if submodule is initialized
-                var testImage = Qt.createQmlObject('import QtQuick; Image { source: "qrc:/calcite/icons/check-24.svg" }', iconShowcaseDialog, "testImage")
-                var available = testImage.status === Image.Ready || testImage.status === Image.Loading
-                testImage.destroy()
-                return available
-            }
+                ColumnLayout {
+                    id: themeLayout
+                    Switch {
+                        id: themeSwitch
+                        text: checked ? "Dark Mode" : "Light Mode"
+                        Layout.alignment: Qt.AlignRight
+                        enabled: !C.Calcite.useSystemTheme
+                        property var selectedTheme: themeSwitch.checked ? C.Calcite.Dark : C.Calcite.Light
 
-            IconShowcase {
-                anchors.fill: parent
-                visible: iconShowcaseDialog.iconsAvailable
-                submoduleInitialized: iconShowcaseDialog.iconsAvailable
-            }
-
-            Label {
-                anchors.centerIn: parent
-                visible: !iconShowcaseDialog.iconsAvailable
-                text: "Icons not available.\n\nInitialize the submodule and rebuild:\ngit submodule update --init --recursive"
-                horizontalAlignment: Text.AlignHCenter
-                font.pixelSize: 14
-            }
-        }
-
-        Drawer {
-            id: drawer
-            width: 0.66 * mapView.width
-            height: mapView.height
-            Column {
-                StackLayout {
-                    id: stackLayout
-
-                    PageIndicator {
-                        currentIndex: stackLayout.currentIndex
-                        count: stackLayout.count
-                        interactive: true
-                    }
-
-                    Page {}
-                    Page {// ...
-                    }
-                    Page {// ...
-                    }
-                }
-            }
-        }
-
-        Menu {
-            id: contextMenu
-            MenuItem {
-                text: "Cut"
-            }
-            MenuItem {
-                text: "Copy"
-            }
-            MenuSeparator {}
-            MenuItem {
-                text: "Paste"
-            }
-        }
-
-        Frame {
-            id: pane
-            enabled: enabler.checked
-            anchors.centerIn: parent
-            ColumnLayout {
-                TextField {
-                    placeholderText: "Textfield"
-                    Layout.alignment: Qt.AlignHCenter
-                }
-
-                TextField {
-                    placeholderText: "Numbers 0-10"
-                    Layout.alignment: Qt.AlignHCenter
-                    validator: IntValidator {
-                        bottom: 0
-                        top: 10
-                    }
-                }
-                Button {
-                    Layout.alignment: Qt.AlignHCenter
-                    text: "Open Dialog"
-                    onPressed: {
-                        dialog.visible = true
-                    }
-                }
-                Button {
-                    Layout.alignment: Qt.AlignHCenter
-                    text: "Open Menu"
-                    flat: true
-                    onPressed: {
-                        contextMenu.popup()
-                    }
-                }
-                RoundButton {
-                    Layout.alignment: Qt.AlignHCenter
-                    text: "Round button "
-                }
-                RoundButton {
-                    Layout.alignment: Qt.AlignHCenter
-                    text: "Round button flat"
-                    flat: true
-                }
-                GroupBox {
-                    title: "Group box"
-                    RowLayout {
-                        RadioButton {
-                            text: "Radio button 1"
-                            checked: true
+                        Binding {
+                            target: C.Calcite
+                            property: "theme"
+                            value: themeSwitch.enabled ? themeSwitch.selectedTheme : Application.styleHints.colorScheme
                         }
-                        RadioButton {
-                            text: "Radio button 2"
-                        }
+
+
                     }
-                }
-                Column {
-                    spacing: 4
-                    topPadding: 4
-                    bottomPadding: 4
-                    anchors.horizontalCenter: parent.horizontalCenter
                     CheckBox {
-                        id: parentCheck
-                        text: "Root Checkbox"
-                        checkState: {
-                            if (child1.checked && child2.checked) {
-                                return Qt.Checked
-                            } else if (!child1.checked && !child2.checked) {
-                                return Qt.Unchecked
-                            } else {
-                                return Qt.PartiallyChecked
-                            }
+                        id: enabler
+                        text: "Enabled"
+                        checked: true
+                    }
+                    CheckBox {
+                        id: useSystemThemeCheckBox
+                        text: "Use System Theme"
+                        checked: true
+
+                        Binding {
+                            target: C.Calcite
+                            property: "useSystemTheme"
+                            value: useSystemThemeCheckBox.checked
+                        }
+                        Binding {
+                            target: C.Calcite
+                            property: "theme"
+                            value: useSystemThemeCheckBox.checked ? Application.styleHints.colorScheme :
+                                                                    themeSwitch.selectedTheme
+                        }
+                    }
+                }
+            }
+
+            Dialog {
+                id: dialog
+                title: "Dialog"
+                parent: Overlay.overlay
+                anchors.centerIn: parent
+                modal: true
+                standardButtons: Dialog.Ok | Dialog.Cancel | Dialog.Help
+
+                // Responsive sizing instead of scaling
+                width: Math.min(400, appWindow.width * 0.85)
+                height: Math.min(300, appWindow.height * 0.85)
+
+                // Black tinted background
+                Overlay.modal: Rectangle {
+                    color: "#80000000"  // 50% transparent black
+                }
+                Pane {
+                    anchors.fill: parent
+                    clip: true
+                    contentItem: ListView {
+                        clip: true
+                        anchors.fill: parent
+                        model: ["Option 1", "Option 2", "Option 3", "Option 4", "Option 5", "Option 6"]
+                        ScrollBar.vertical: ScrollBar {}
+                        delegate: RadioDelegate {
+                            width: ListView.view.width
+                            text: modelData
+                            // Prevent text overflow
+                            clip: true
+                        }
+                    }
+                }
+            }
+
+            Dialog {
+                id: iconShowcaseDialog
+                parent: Overlay.overlay
+                anchors.centerIn: parent
+                modal: true
+                standardButtons: Dialog.Close
+                width: Math.min(600, appWindow.width * 0.9)
+                height: Math.min(500, appWindow.height * 0.9)
+
+                // Black tinted background
+                Overlay.modal: Rectangle {
+                    color: "#80000000"
+                }
+
+                // Only available if submodule is initialized
+                property bool iconsAvailable: {
+                    // Try to load an icon to check if submodule is initialized
+                    var testImage = Qt.createQmlObject('import QtQuick; Image { source: "qrc:/calcite/icons/check-24.svg" }', iconShowcaseDialog, "testImage")
+                    var available = testImage.status === Image.Ready || testImage.status === Image.Loading
+                    testImage.destroy()
+                    return available
+                }
+
+                IconShowcase {
+                    anchors.fill: parent
+                    visible: iconShowcaseDialog.iconsAvailable
+                    submoduleInitialized: iconShowcaseDialog.iconsAvailable
+                }
+
+                Label {
+                    anchors.centerIn: parent
+                    width: Math.min(implicitWidth, parent.width - 40)
+                    visible: !iconShowcaseDialog.iconsAvailable
+                    text: "Icons not available.\n\nInitialize the submodule and rebuild:\ngit submodule update --init --recursive"
+                    horizontalAlignment: Text.AlignHCenter
+                    font.pixelSize: 14
+                    wrapMode: Text.WordWrap
+                    clip: true
+                }
+            }
+
+            Drawer {
+                id: drawer
+                width: 0.66 * mapView.width
+                height: mapView.height
+                Column {
+                    StackLayout {
+                        id: stackLayout
+
+                        PageIndicator {
+                            currentIndex: stackLayout.currentIndex
+                            count: stackLayout.count
+                            interactive: true
                         }
 
-                        onClicked: {
-                            let newState = checkState
-                            child1.checked = newState
-                            child2.checked = newState
+                        Page {}
+                        Page {// ...
+                        }
+                        Page {// ...
+                        }
+                    }
+                }
+            }
+
+            Menu {
+                id: contextMenu
+                MenuItem {
+                    text: "Cut"
+                }
+                MenuItem {
+                    text: "Copy"
+                }
+                MenuSeparator {}
+                MenuItem {
+                    text: "Paste"
+                }
+            }
+
+            Frame {
+                id: pane
+                enabled: enabler.checked
+                anchors.centerIn: parent
+
+                implicitWidth: columnLayout.implicitWidth + leftPadding + rightPadding
+                implicitHeight: columnLayout.implicitHeight + topPadding + bottomPadding
+
+                scale: Math.min(1.0,
+                                Math.min(mapView.width * 0.8 / Math.max(implicitWidth, 1),
+                                         mapView.height * 0.75 / Math.max(implicitHeight, 1)))
+                transformOrigin: Item.Center
+
+                ColumnLayout {
+                    id: columnLayout
+                    TextField {
+                        placeholderText: "Textfield"
+                        Layout.alignment: Qt.AlignHCenter
+                    }
+
+                    TextField {
+                        placeholderText: "Numbers 0-10"
+                        Layout.alignment: Qt.AlignHCenter
+                        validator: IntValidator {
+                            bottom: 0
+                            top: 10
+                        }
+                    }
+                    Button {
+                        Layout.alignment: Qt.AlignHCenter
+                        text: "Open Dialog"
+                        onPressed: {
+                            dialog.visible = true
+                        }
+                    }
+                    Button {
+                        Layout.alignment: Qt.AlignHCenter
+                        text: "Open Menu"
+                        flat: true
+                        onPressed: {
+                            contextMenu.popup()
+                        }
+                    }
+                    RoundButton {
+                        Layout.alignment: Qt.AlignHCenter
+                        text: "Round button "
+                    }
+                    RoundButton {
+                        Layout.alignment: Qt.AlignHCenter
+                        text: "Round button flat"
+                        flat: true
+                    }
+                    GroupBox {
+                        title: "Group box"
+                        RowLayout {
+                            RadioButton {
+                                text: "Radio button 1"
+                                checked: true
+                            }
+                            RadioButton {
+                                text: "Radio button 2"
+                            }
                         }
                     }
                     Column {
                         spacing: 4
-                        leftPadding: 32
-                        anchors.horizontalCenter: parent.horizontalCenter
-
+                        topPadding: 4
+                        bottomPadding: 4
+                        Layout.alignment: Qt.AlignHCenter
                         CheckBox {
-                            id: child1
-                            text: "Checkbox 1"
-                            checked: false
-                            onClicked: parentCheck.forceActiveFocus()
+                            id: parentCheck
+                            text: "Root Checkbox"
+                            checkState: {
+                                if (child1.checked && child2.checked) {
+                                    return Qt.Checked
+                                } else if (!child1.checked && !child2.checked) {
+                                    return Qt.Unchecked
+                                } else {
+                                    return Qt.PartiallyChecked
+                                }
+                            }
+
+                            onClicked: {
+                                let newState = checkState
+                                child1.checked = newState
+                                child2.checked = newState
+                            }
                         }
+                        Column {
+                            spacing: 4
+                            leftPadding: 32
+                            anchors.horizontalCenter: parent.horizontalCenter
 
-                        CheckBox {
-                            id: child2
-                            text: "Checkbox 2"
-                            checked: true
-                            onClicked: parentCheck.forceActiveFocus()
+                            CheckBox {
+                                id: child1
+                                text: "Checkbox 1"
+                                checked: false
+                                onClicked: parentCheck.forceActiveFocus()
+                            }
+
+                            CheckBox {
+                                id: child2
+                                text: "Checkbox 2"
+                                checked: true
+                                onClicked: parentCheck.forceActiveFocus()
+                            }
                         }
                     }
-                }
-                ComboBox {
-                    Layout.alignment: Qt.AlignHCenter
-                    model: ["Banana", "Apple", "Coconut"]
+                    ComboBox {
+                        Layout.alignment: Qt.AlignHCenter
+                        model: ["Banana", "Apple", "Coconut"]
+                    }
+
+                    Switch {
+                        text: "Switch"
+                        Layout.alignment: Qt.AlignHCenter
+                    }
+
+                    Slider {
+                        Layout.alignment: Qt.AlignHCenter
+                    }
+
+                    RangeSlider {
+                        Layout.alignment: Qt.AlignHCenter
+                    }
+
+                    BusyIndicator {
+                        Layout.alignment: Qt.AlignHCenter
+                    }
+                    Label {
+                        text: "Loading..."
+                        Layout.alignment: Qt.AlignHCenter
+                    }
+                    SpinBox {
+                        Layout.alignment: Qt.AlignHCenter
+                        value: 5
+                    }
+                    Label {
+                        text: "Progress Bar"
+                    }
+                    ProgressBar {
+                        Layout.fillHeight: false
+                        Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                        Layout.fillWidth: true
+                        from: 0
+                        to: 100
+                        value: 50
+                        clip: true
+                        indeterminate: true
+                    }
                 }
 
-                Switch {
-                    text: "Switch"
-                    Layout.alignment: Qt.AlignHCenter
-                }
+            }
 
-                Slider {
-                    Layout.alignment: Qt.AlignHCenter
+            // Icon Showcase Button - Bottom Left
+            Button {
+                id: iconButton
+                anchors {
+                    left: parent.left
+                    bottom: parent.attributionTop
+                    margins: 10
                 }
+                text: "Calcite Icons"
+                visible: appWindow.calciteIconsAvailable
+                enabled: appWindow.calciteIconsAvailable
 
-                RangeSlider {
-                    Layout.alignment: Qt.AlignHCenter
-                }
+                // Scale to fit smaller screens
+                scale: Math.min(1.0,
+                                Math.min(mapView.width * 0.3 / Math.max(implicitWidth, 1),
+                                         mapView.height * 0.15 / Math.max(implicitHeight, 1)))
+                transformOrigin: Item.BottomLeft
 
-                BusyIndicator {
-                    Layout.alignment: Qt.AlignHCenter
-                }
-                Label {
-                    text: "Loading..."
-                    Layout.alignment: Qt.AlignHCenter
-                }
-                SpinBox {
-                    Layout.alignment: Qt.AlignHCenter
-                    value: 5
-                }
-                Label {
-                    text: "Progress Bar"
-                }
-                ProgressBar {
-                    Layout.fillHeight: false
-                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    Layout.fillWidth: true
-                    from: 0
-                    to: 100
-                    value: 50
-                    clip: true
-                    indeterminate: true
+                onPressed: {
+                    iconShowcaseDialog.open()
                 }
             }
-        }
 
-        // Icon Showcase Button - Bottom Left
-        Button {
-            anchors {
-                left: parent.left
-                bottom: parent.attributionTop
-                margins: 10
-            }
-            text: "Calcite Icons"
-            visible: appWindow.calciteIconsAvailable
-            enabled: appWindow.calciteIconsAvailable
-            onPressed: {
-                iconShowcaseDialog.open()
-            }
-        }
-
-        ToolBar {
-            enabled: enabler.checked
-            anchors {
-                right: parent.right
-                bottom: parent.attributionTop
-                margins: 5
-            }
-            ColumnLayout {
-
-                ToolButton {
-                    icon.source: "qrc:/esri.com/imports/Calcite/images/check.svg"
-                    checkable: true
-                    text: "Checkable ToolButton"
+            ToolBar {
+                id: bottomRightToolbar
+                enabled: enabler.checked
+                anchors {
+                    right: parent.right
+                    bottom: parent.attributionTop
+                    margins: 5
                 }
+                implicitWidth: toolbarLayout.implicitWidth + leftPadding + rightPadding
+                implicitHeight: toolbarLayout.implicitHeight + topPadding + bottomPadding
+                scale: Math.min(1.0,
+                                Math.min(mapView.width * 0.3 / Math.max(implicitWidth, 1),
+                                         mapView.height * 0.3 / Math.max(implicitHeight, 1)))
+                transformOrigin: Item.BottomRight
 
-                ToolSeparator {
-                    Layout.fillWidth: true
-                    orientation: Qt.Horizontal
-                }
+                ColumnLayout {
+                    id: toolbarLayout
 
-                ToolButton {
-                    Layout.fillWidth: true
-                    flat: true
-                    checkable: true
-                    text: "Regular Flat ToolButton "
+                    ToolButton {
+                        icon.source: "qrc:/esri.com/imports/Calcite/images/check.svg"
+                        checkable: true
+                        text: "Checkable ToolButton"
+                    }
+
+                    ToolSeparator {
+                        Layout.fillWidth: true
+                        orientation: Qt.Horizontal
+                    }
+
+                    ToolButton {
+                        Layout.fillWidth: true
+                        flat: true
+                        checkable: true
+                        text: "Regular Flat ToolButton "
+                    }
                 }
             }
         }

--- a/calcite/demo/qml/main.qml
+++ b/calcite/demo/qml/main.qml
@@ -63,9 +63,9 @@ ApplicationWindow {
                 }
                 z: 100
 
-                // Scale to fit smaller screens
                 implicitWidth: themeLayout.implicitWidth + leftPadding + rightPadding
                 implicitHeight: themeLayout.implicitHeight + topPadding + bottomPadding
+                // Scale to fit smaller screens
                 scale: Math.min(1.0,
                                 Math.min(mapView.width * 0.3 / Math.max(implicitWidth, 1),
                                          mapView.height * 0.3 / Math.max(implicitHeight, 1)))
@@ -120,14 +120,12 @@ ApplicationWindow {
                 anchors.centerIn: parent
                 modal: true
                 standardButtons: Dialog.Ok | Dialog.Cancel | Dialog.Help
-
-                // Responsive sizing instead of scaling
                 width: Math.min(400, appWindow.width * 0.85)
                 height: Math.min(300, appWindow.height * 0.85)
 
                 // Black tinted background
                 Overlay.modal: Rectangle {
-                    color: "#80000000"  // 50% transparent black
+                    color: "#80000000"
                 }
                 Pane {
                     anchors.fill: parent


### PR DESCRIPTION
This Pr has the following changes:
- `main.qml ` - aded `scale` property to frame and panes. Added top and bottom inset for android. Added black tinted bg when dialogue is open.
- ` IconShowcase.qml` - added `canOpenLocalFolders` to track platform.  Open Folder button is visible/hidden based on this value. Fixed open folder functionality for windows.
- `calcite_test.pro` - Removed multimedia for iOS. This was causing builds to fail for iOS.

Note:- majority of the changes as shown in the diff are due to indentation. the above mentioned changes are the only additions.