### PR TITLE
Identity-aware proxy

### DIFF
--- a/uitools/common/CMakeLists.txt
+++ b/uitools/common/CMakeLists.txt
@@ -127,6 +127,24 @@ set(ESRI_ARCGISRUNTIME_TOOLKIT_COMMON_INCLUDES
     ../common/src
 )
 
+set(ESRI_ARCGISRUNTIME_TOOLKIT_COMMON_IOS_FRAMEWORKS)
+
+if(IOS)
+    list(APPEND ESRI_ARCGISRUNTIME_TOOLKIT_COMMON_SOURCES
+        ../common/src/IOS/IOSWebAuthenticationSession.mm
+    )
+    list(APPEND ESRI_ARCGISRUNTIME_TOOLKIT_COMMON_HEADERS
+        ../common/src/IOS/IOSWebAuthenticationSession.h
+    )
+    list(APPEND ESRI_ARCGISRUNTIME_TOOLKIT_COMMON_INCLUDES
+        ../common/src/IOS
+    )
+
+    list(APPEND ESRI_ARCGISRUNTIME_TOOLKIT_COMMON_IOS_FRAMEWORKS
+        "-framework AuthenticationServices"
+    )
+endif()
+
 set(ESRI_ARCGISRUNTIME_TOOLKIT_COMMON_IMAGES
     ../common/images/basemap.svg
     ../common/images/chevron-down.svg

--- a/uitools/common/common.pri
+++ b/uitools/common/common.pri
@@ -27,6 +27,15 @@
 
     SOURCES += $$files($$TOOLKIT_COMMON_SRC/*.cpp)
 
+    ios {
+        INCLUDEPATH += $$TOOLKIT_COMMON_SRC/IOS
+        DEPENDPATH += $$TOOLKIT_COMMON_SRC/IOS
+        HEADERS += $$files($$TOOLKIT_COMMON_SRC/IOS/*.h)
+        SOURCES += $$files($$TOOLKIT_COMMON_SRC/IOS/*.mm)
+
+        LIBS += -framework AuthenticationServices
+    }
+
     RESOURCES += $$PWD/images/esri_arcgisruntime_toolkit_common_images.qrc
 
     TOOLKIT_COMMON_INCLUDED = true

--- a/uitools/common/src/AuthenticatorController.cpp
+++ b/uitools/common/src/AuthenticatorController.cpp
@@ -26,6 +26,7 @@
 #include <QStringLiteral>
 #include <QUrl>
 #include <QtGlobal>
+#include <QGuiApplication>
 
 // Maps SDK headers
 #include <ArcGISRuntimeEnvironment.h>
@@ -617,56 +618,26 @@ namespace Esri::ArcGISRuntime::Toolkit
     });
 
     m_iosWebAuthenticationSession->start(m_currentOAuthUserLogoutPrompt->logoutUrl(), callbackScheme);
-    return;
-#endif
+#else
+    // for IAP logout workflows, there is no way to get back to the app. The callback URI does not fire back to the app after logging out.
+    // As such, we just open the browser, allow the user to do this, and then assume whenever control returns to the app, it works sucessfully.
 
-    auto* oauthFlow = new CustomOAuth2AuthorizationCodeFlow(m_currentOAuthUserLogoutPrompt->logoutUrl(), m_currentOAuthUserLogoutPrompt.get());
-
-    auto* callbackReplyHandler = new QOAuthUriSchemeReplyHandler(m_currentOAuthUserLogoutPrompt.get());
-
-    connect(callbackReplyHandler, &QOAuthUriSchemeReplyHandler::callbackReceived, this, [this, oauthFlow](const QVariantMap& values)
+    m_appState = QGuiApplication::applicationState();
+    m_logoutStateChangeConnection = connect(qGuiApp, &QGuiApplication::applicationStateChanged, this, [this](Qt::ApplicationState state)
     {
-      if (!values.contains("code"))
+      const auto previousState = m_appState;
+      m_appState = state;
+      if (previousState != Qt::ApplicationActive && m_appState == Qt::ApplicationActive)
       {
-        m_currentOAuthUserLogoutPrompt->respondWithError("There was an error obtaining the authorization code");
+        constexpr auto loggedOut = true;
+        m_currentOAuthUserLogoutPrompt->respond(loggedOut);
         finishOAuthExternalBrowserFlow_();
-        return;
+        disconnect(m_logoutStateChangeConnection);
       }
-
-      const auto code = values.value("code").toString();
-      oauthFlow->setAuthorizationCode(code);
-      emit oauthFlow->granted();
     });
 
-    oauthFlow->setAuthorizationUrl(m_currentOAuthUserLogoutPrompt->logoutUrl());
-
-    if (m_currentOAuthUserConfiguration)
-    { // identity-aware proxy workflows will not have any OAuthUserConfiguration
-      oauthFlow->setClientIdentifier(m_currentOAuthUserConfiguration->clientId());
-    }
-
-    connect(oauthFlow, &QAbstractOAuth::authorizeWithBrowser, this, &QDesktopServices::openUrl);
-    connect(oauthFlow, &QAbstractOAuth::granted, this, [callbackReplyHandler, this]()
-    {
-      callbackReplyHandler->close();
-
-      constexpr auto loggedOut = true;
-      m_currentOAuthUserLogoutPrompt->respond(loggedOut);
-      finishOAuthExternalBrowserFlow_();
-    });
-
-    callbackReplyHandler->setRedirectUrl(m_currentOAuthUserLogoutPrompt->redirectUri());
-    oauthFlow->setReplyHandler(callbackReplyHandler);
-
-    if (callbackReplyHandler->listen())
-    {
-      oauthFlow->grant();
-    }
-    else
-    {
-      m_currentOAuthUserLogoutPrompt->respondWithError("There was an error establishing the redirect URL listener");
-      finishOAuthExternalBrowserFlow_();
-    }
+    QDesktopServices::openUrl(m_currentOAuthUserLogoutPrompt->logoutUrl());
+#endif // Q_OS_IOS
   }
 
   void AuthenticatorController::finishOAuthExternalBrowserFlow_()

--- a/uitools/common/src/AuthenticatorController.cpp
+++ b/uitools/common/src/AuthenticatorController.cpp
@@ -575,6 +575,10 @@ namespace Esri::ArcGISRuntime::Toolkit
   void AuthenticatorController::processOAuthExternalBrowserLogout_()
   {
 #ifdef Q_OS_IOS
+    // IAP logout provides no way to get back to the app, so m_iosWebAuthenticationSession is a custom implementation
+    // that pops Safari (or whatever system default browser) up within the same app window, and it contains a cancel
+    // button that allows users to more gracefully return to the app, and this code to more gracefully know when it
+    // happens.
     if (!m_currentOAuthUserLogoutPrompt)
     {
       return;

--- a/uitools/common/src/AuthenticatorController.cpp
+++ b/uitools/common/src/AuthenticatorController.cpp
@@ -25,6 +25,7 @@
 #include <QSslSocket>
 #include <QStringLiteral>
 #include <QUrl>
+#include <QtGlobal>
 
 // Maps SDK headers
 #include <ArcGISRuntimeEnvironment.h>
@@ -36,6 +37,7 @@
 #include <Authentication/OAuthUserConfiguration.h>
 #include <Authentication/OAuthUserCredential.h>
 #include <Authentication/OAuthUserLoginPrompt.h>
+#include <Authentication/OAuthUserLogoutPrompt.h>
 #include <Authentication/PasswordCredential.h>
 #include <Authentication/ServerTrustCredential.h>
 #include <Authentication/TokenCredential.h>
@@ -47,6 +49,10 @@
 #include "CustomOAuth2AuthorizationCodeFlow.h"
 #include "NetworkAuthenticationChallengeRelay.h"
 
+#ifdef Q_OS_IOS
+#include "IOS/IOSWebAuthenticationSession.h"
+#endif
+
 // STL headers
 #include <optional>
 
@@ -56,6 +62,15 @@ using Esri::ArcGISRuntime::Authentication::AuthenticationManager;
 
 namespace Esri::ArcGISRuntime::Toolkit
 {
+
+  namespace
+  {
+    bool isInProcessOAuthRedirect(const QString& redirectUri)
+    {
+      return redirectUri == QStringLiteral("urn:ietf:wg:oauth:2.0:oob") || // this is the default value for "oob"
+             redirectUri.contains(QStringLiteral("oob")); // this is what the Qt docs indicate to check for
+    }
+  } // namespace
 
   /*!
     \internal
@@ -68,16 +83,14 @@ namespace Esri::ArcGISRuntime::Toolkit
     m_arcGISAuthenticationChallengeRelay = std::make_unique<ArcGISAuthenticationChallengeRelay>(this);
     m_networkAuthenticationChallengeRelay = std::make_unique<NetworkAuthenticationChallengeRelay>(this);
 
-    // listen for OAuth prompts
+    // listen for OAuth login prompts
     connect(ArcGISRuntimeEnvironment::authenticationManager(), &AuthenticationManager::oAuthUserLoginPromptIssued, this,
-            [this](OAuthUserLoginPrompt* currentOAuthUserLoginPrompt)
+            [this](OAuthUserLoginPrompt* oAuthUserLoginPrompt)
     {
-      currentOAuthUserLoginPrompt->setParent(nullptr);
-      m_currentOAuthUserLoginPrompt = std::unique_ptr<OAuthUserLoginPrompt>{currentOAuthUserLoginPrompt};
+      oAuthUserLoginPrompt->setParent(nullptr);
+      m_currentOAuthUserLoginPrompt = std::unique_ptr<OAuthUserLoginPrompt>{oAuthUserLoginPrompt};
 
-      if (const auto redirectUrl = m_currentOAuthUserLoginPrompt->redirectUri();
-          redirectUrl == QUrl{"urn:ietf:wg:oauth:2.0:oob"} || // this is the default value for "oob"
-          redirectUrl.contains("oob")) // this is what the Qt docs indicate to check for
+      if (isInProcessOAuthRedirect(m_currentOAuthUserLoginPrompt->redirectUri()))
       { // use embedded web view session for "oob" redirect URI
         emit authorizeUrlChanged();
         emit redirectUriChanged();
@@ -86,6 +99,25 @@ namespace Esri::ArcGISRuntime::Toolkit
       else
       {
         processOAuthExternalBrowserLogin_();
+      }
+    });
+
+    // process logout requests for IAP workflows
+    connect(ArcGISRuntimeEnvironment::authenticationManager(), &AuthenticationManager::oAuthUserLogoutPromptIssued, this,
+            [this](OAuthUserLogoutPrompt* oAuthUserLogoutPrompt)
+    {
+      oAuthUserLogoutPrompt->setParent(nullptr);
+      m_currentOAuthUserLogoutPrompt = std::unique_ptr<OAuthUserLogoutPrompt>{oAuthUserLogoutPrompt};
+
+      if (isInProcessOAuthRedirect(m_currentOAuthUserLogoutPrompt->redirectUri()))
+      {
+        // No support currently for in-process WebView IAP logouts in the toolkit
+        m_currentOAuthUserLogoutPrompt->respondWithError("In-process WebView logouts are not supported.");
+        m_currentOAuthUserLogoutPrompt.reset();
+      }
+      else
+      {
+        processOAuthExternalBrowserLogout_();
       }
     });
   }
@@ -288,7 +320,7 @@ namespace Esri::ArcGISRuntime::Toolkit
     });
   }
 
-  void AuthenticatorController::AuthenticatorController::continueWithUsernamePasswordNetwork_(const QString& username, const QString& password)
+  void AuthenticatorController::continueWithUsernamePasswordNetwork_(const QString& username, const QString& password)
   {
     if (!m_currentNetworkChallenge)
     {
@@ -322,8 +354,38 @@ namespace Esri::ArcGISRuntime::Toolkit
     m_currentOAuthUserLoginPrompt.reset();
   }
 
+  void AuthenticatorController::logoutRespond(bool result)
+  {
+    if (!m_currentOAuthUserLogoutPrompt)
+    {
+      return;
+    }
+
+    m_currentOAuthUserLogoutPrompt->respond(result);
+    m_currentOAuthUserLogoutPrompt.reset();
+  }
+
+  void AuthenticatorController::logoutRespondWithError(const QString& platformError)
+  {
+    if (!m_currentOAuthUserLogoutPrompt)
+    {
+      return;
+    }
+
+    m_currentOAuthUserLogoutPrompt->respondWithError(platformError);
+    m_currentOAuthUserLogoutPrompt.reset();
+  }
+
   void AuthenticatorController::cancel()
   {
+#ifdef Q_OS_IOS
+    if (m_iosWebAuthenticationSession)
+    {
+      m_iosWebAuthenticationSession->cancel();
+      m_iosWebAuthenticationSession.reset();
+    }
+#endif
+
     if (m_currentNetworkChallenge)
     {
       m_currentNetworkChallenge->cancel();
@@ -384,7 +446,17 @@ namespace Esri::ArcGISRuntime::Toolkit
 
   QString AuthenticatorController::redirectUri_() const
   {
-    return m_currentOAuthUserLoginPrompt ? m_currentOAuthUserLoginPrompt->redirectUri() : QString{};
+    if (m_currentOAuthUserLoginPrompt)
+    {
+      return m_currentOAuthUserLoginPrompt->redirectUri();
+    }
+
+    if (m_currentOAuthUserLogoutPrompt)
+    {
+      return m_currentOAuthUserLogoutPrompt->redirectUri();
+    }
+
+    return {};
   }
 
   int AuthenticatorController::previousFailureCount_() const
@@ -404,15 +476,61 @@ namespace Esri::ArcGISRuntime::Toolkit
 
   void AuthenticatorController::processOAuthExternalBrowserLogin_()
   {
+#ifdef Q_OS_IOS
+    if (!m_currentOAuthUserLoginPrompt)
+    {
+      return;
+    }
+
+    const QUrl redirectUri{m_currentOAuthUserLoginPrompt->redirectUri()};
+    const QString callbackScheme = redirectUri.scheme();
+
+    m_iosWebAuthenticationSession = std::make_unique<IOSWebAuthenticationSession>(this);
+
+    connect(m_iosWebAuthenticationSession.get(), &IOSWebAuthenticationSession::completed, this, [this](const QUrl& callbackUrl)
+    {
+      if (!m_currentOAuthUserLoginPrompt)
+      {
+        finishOAuthExternalBrowserFlow_();
+        return;
+      }
+
+      m_currentOAuthUserLoginPrompt->respond(callbackUrl);
+      finishOAuthExternalBrowserFlow_();
+    });
+
+    connect(m_iosWebAuthenticationSession.get(), &IOSWebAuthenticationSession::canceled, this, [this]()
+    {
+      if (m_currentOAuthUserLoginPrompt)
+      {
+        m_currentOAuthUserLoginPrompt->respondWithError(QStringLiteral("User canceled"));
+      }
+      finishOAuthExternalBrowserFlow_();
+    });
+
+    connect(m_iosWebAuthenticationSession.get(), &IOSWebAuthenticationSession::failed, this, [this](const QString& error)
+    {
+      if (m_currentOAuthUserLoginPrompt)
+      {
+        m_currentOAuthUserLoginPrompt->respondWithError(error);
+      }
+      finishOAuthExternalBrowserFlow_();
+    });
+
+    m_iosWebAuthenticationSession->start(m_currentOAuthUserLoginPrompt->authorizeUrl(), callbackScheme);
+    return;
+#endif
+
     auto* oauthFlow = new CustomOAuth2AuthorizationCodeFlow(m_currentOAuthUserLoginPrompt->authorizeUrl(), m_currentOAuthUserLoginPrompt.get());
 
     auto* callbackReplyHandler = new QOAuthUriSchemeReplyHandler(m_currentOAuthUserLoginPrompt.get());
+
     connect(callbackReplyHandler, &QOAuthUriSchemeReplyHandler::callbackReceived, this, [this, oauthFlow](const QVariantMap& values)
     {
       if (!values.contains("code"))
       {
         m_currentOAuthUserLoginPrompt->respondWithError("There was an error obtaining the authorization code");
-        finishOAuthExternalBrowserChallengeFlow_();
+        finishOAuthExternalBrowserFlow_();
         return;
       }
 
@@ -422,7 +540,11 @@ namespace Esri::ArcGISRuntime::Toolkit
     });
 
     oauthFlow->setAuthorizationUrl(m_currentOAuthUserLoginPrompt->authorizeUrl());
-    oauthFlow->setClientIdentifier(m_currentOAuthUserConfiguration->clientId());
+
+    if (m_currentOAuthUserConfiguration)
+    { // identity-aware proxy workflows will not have any OAuthUserConfiguration
+      oauthFlow->setClientIdentifier(m_currentOAuthUserConfiguration->clientId());
+    }
 
     connect(oauthFlow, &QAbstractOAuth::authorizeWithBrowser, this, &QDesktopServices::openUrl);
     connect(oauthFlow, &QAbstractOAuth::granted, this, [callbackReplyHandler, oauthFlow, this]()
@@ -430,10 +552,9 @@ namespace Esri::ArcGISRuntime::Toolkit
       callbackReplyHandler->close();
 
       // this needs to be in the form of redirectUri?code=authCode
-      const auto formattedResponseUrl =
-        QUrl{QString("%1?code=%2").arg(m_currentOAuthUserConfiguration->redirectUri(), oauthFlow->authorizationCode())};
+      const auto formattedResponseUrl = QUrl{QString("%1?code=%2").arg(m_currentOAuthUserLoginPrompt->redirectUri(), oauthFlow->authorizationCode())};
       m_currentOAuthUserLoginPrompt->respond(formattedResponseUrl);
-      finishOAuthExternalBrowserChallengeFlow_();
+      finishOAuthExternalBrowserFlow_();
     });
 
     callbackReplyHandler->setRedirectUrl(m_currentOAuthUserLoginPrompt->redirectUri());
@@ -446,14 +567,122 @@ namespace Esri::ArcGISRuntime::Toolkit
     else
     {
       m_currentOAuthUserLoginPrompt->respondWithError("There was an error establishing the redirect URL listener");
-      finishOAuthExternalBrowserChallengeFlow_();
+      finishOAuthExternalBrowserFlow_();
     }
   }
 
-  void AuthenticatorController::finishOAuthExternalBrowserChallengeFlow_()
+  void AuthenticatorController::processOAuthExternalBrowserLogout_()
+  {
+#ifdef Q_OS_IOS
+    if (!m_currentOAuthUserLogoutPrompt)
+    {
+      return;
+    }
+
+    const QUrl redirectUri{m_currentOAuthUserLogoutPrompt->redirectUri()};
+    const QString callbackScheme = redirectUri.scheme();
+
+    m_iosWebAuthenticationSession = std::make_unique<IOSWebAuthenticationSession>(this);
+
+    connect(m_iosWebAuthenticationSession.get(), &IOSWebAuthenticationSession::completed, this, [this](const QUrl& /*callbackUrl*/)
+    {
+      if (m_currentOAuthUserLogoutPrompt)
+      {
+        constexpr auto loggedOut = true;
+        m_currentOAuthUserLogoutPrompt->respond(loggedOut);
+      }
+      finishOAuthExternalBrowserFlow_();
+    });
+
+    connect(m_iosWebAuthenticationSession.get(), &IOSWebAuthenticationSession::canceled, this, [this]()
+    {
+      if (m_currentOAuthUserLogoutPrompt)
+      {
+        // currently with IAP, there is no callback mechanism to return to the app once the user logs out,
+        // so we advise to simply cancel the Safari session to return to the app, which ends up here and
+        // we assume it was successful.
+        constexpr auto loggedOut = true;
+        m_currentOAuthUserLogoutPrompt->respond(loggedOut);
+      }
+      finishOAuthExternalBrowserFlow_();
+    });
+
+    connect(m_iosWebAuthenticationSession.get(), &IOSWebAuthenticationSession::failed, this, [this](const QString& error)
+    {
+      if (m_currentOAuthUserLogoutPrompt)
+      {
+        m_currentOAuthUserLogoutPrompt->respondWithError(error);
+      }
+      finishOAuthExternalBrowserFlow_();
+    });
+
+    m_iosWebAuthenticationSession->start(m_currentOAuthUserLogoutPrompt->logoutUrl(), callbackScheme);
+    return;
+#endif
+
+    auto* oauthFlow = new CustomOAuth2AuthorizationCodeFlow(m_currentOAuthUserLogoutPrompt->logoutUrl(), m_currentOAuthUserLogoutPrompt.get());
+
+    auto* callbackReplyHandler = new QOAuthUriSchemeReplyHandler(m_currentOAuthUserLogoutPrompt.get());
+
+    connect(callbackReplyHandler, &QOAuthUriSchemeReplyHandler::callbackReceived, this, [this, oauthFlow](const QVariantMap& values)
+    {
+      if (!values.contains("code"))
+      {
+        m_currentOAuthUserLogoutPrompt->respondWithError("There was an error obtaining the authorization code");
+        finishOAuthExternalBrowserFlow_();
+        return;
+      }
+
+      const auto code = values.value("code").toString();
+      oauthFlow->setAuthorizationCode(code);
+      emit oauthFlow->granted();
+    });
+
+    oauthFlow->setAuthorizationUrl(m_currentOAuthUserLogoutPrompt->logoutUrl());
+
+    if (m_currentOAuthUserConfiguration)
+    { // identity-aware proxy workflows will not have any OAuthUserConfiguration
+      oauthFlow->setClientIdentifier(m_currentOAuthUserConfiguration->clientId());
+    }
+
+    connect(oauthFlow, &QAbstractOAuth::authorizeWithBrowser, this, &QDesktopServices::openUrl);
+    connect(oauthFlow, &QAbstractOAuth::granted, this, [callbackReplyHandler, this]()
+    {
+      callbackReplyHandler->close();
+
+      constexpr auto loggedOut = true;
+      m_currentOAuthUserLogoutPrompt->respond(loggedOut);
+      finishOAuthExternalBrowserFlow_();
+    });
+
+    callbackReplyHandler->setRedirectUrl(m_currentOAuthUserLogoutPrompt->redirectUri());
+    oauthFlow->setReplyHandler(callbackReplyHandler);
+
+    if (callbackReplyHandler->listen())
+    {
+      oauthFlow->grant();
+    }
+    else
+    {
+      m_currentOAuthUserLogoutPrompt->respondWithError("There was an error establishing the redirect URL listener");
+      finishOAuthExternalBrowserFlow_();
+    }
+  }
+
+  void AuthenticatorController::finishOAuthExternalBrowserFlow_()
   {
     m_currentOAuthUserConfiguration = nullptr;
     m_currentOAuthUserLoginPrompt.reset();
+
+    m_currentOAuthUserLogoutPrompt.reset();
+
+#ifdef Q_OS_IOS
+    if (m_iosWebAuthenticationSession)
+    {
+      m_iosWebAuthenticationSession->cancel();
+      m_iosWebAuthenticationSession.reset();
+    }
+#endif
   }
 
 } // namespace Esri::ArcGISRuntime::Toolkit

--- a/uitools/common/src/AuthenticatorController.cpp
+++ b/uitools/common/src/AuthenticatorController.cpp
@@ -68,8 +68,7 @@ namespace Esri::ArcGISRuntime::Toolkit
   {
     bool isInProcessOAuthRedirect(const QString& redirectUri)
     {
-      return redirectUri == QStringLiteral("urn:ietf:wg:oauth:2.0:oob") || // this is the default value for "oob"
-             redirectUri.contains(QStringLiteral("oob")); // this is what the Qt docs indicate to check for
+      return redirectUri == QStringLiteral("urn:ietf:wg:oauth:2.0:oob");
     }
   } // namespace
 

--- a/uitools/common/src/AuthenticatorController.cpp
+++ b/uitools/common/src/AuthenticatorController.cpp
@@ -602,7 +602,7 @@ namespace Esri::ArcGISRuntime::Toolkit
     m_iosWebAuthenticationSession->start(m_currentOAuthUserLogoutPrompt->logoutUrl(), callbackScheme);
 #else
     // for IAP logout workflows, there is no way to get back to the app. The callback URI does not fire back to the app after logging out.
-    // As such, we just open the browser, allow the user to do this, and then assume whenever control returns to the app, it works sucessfully.
+    // As such, we just open the browser, allow the user to do this, and then assume whenever control returns to the app, it works successfully.
 
     m_appState = QGuiApplication::applicationState();
     m_logoutStateChangeConnection = connect(qGuiApp, &QGuiApplication::applicationStateChanged, this, [this](Qt::ApplicationState state)

--- a/uitools/common/src/AuthenticatorController.cpp
+++ b/uitools/common/src/AuthenticatorController.cpp
@@ -355,28 +355,6 @@ namespace Esri::ArcGISRuntime::Toolkit
     m_currentOAuthUserLoginPrompt.reset();
   }
 
-  void AuthenticatorController::logoutRespond(bool result)
-  {
-    if (!m_currentOAuthUserLogoutPrompt)
-    {
-      return;
-    }
-
-    m_currentOAuthUserLogoutPrompt->respond(result);
-    m_currentOAuthUserLogoutPrompt.reset();
-  }
-
-  void AuthenticatorController::logoutRespondWithError(const QString& platformError)
-  {
-    if (!m_currentOAuthUserLogoutPrompt)
-    {
-      return;
-    }
-
-    m_currentOAuthUserLogoutPrompt->respondWithError(platformError);
-    m_currentOAuthUserLogoutPrompt.reset();
-  }
-
   void AuthenticatorController::cancel()
   {
 #ifdef Q_OS_IOS

--- a/uitools/common/src/AuthenticatorController.h
+++ b/uitools/common/src/AuthenticatorController.h
@@ -149,6 +149,8 @@ namespace Esri::ArcGISRuntime::Toolkit
     std::unique_ptr<IOSWebAuthenticationSession> m_iosWebAuthenticationSession;
 #endif
 
+    QMetaObject::Connection m_logoutStateChangeConnection;
+    Qt::ApplicationState m_appState = Qt::ApplicationState::ApplicationActive;
     std::mutex m_mutex;
   };
 

--- a/uitools/common/src/AuthenticatorController.h
+++ b/uitools/common/src/AuthenticatorController.h
@@ -20,6 +20,7 @@
 #include <QHash>
 #include <QObject>
 #include <QQmlEngine>
+#include <QtGlobal>
 
 // STL headers
 #include <memory>
@@ -33,6 +34,7 @@ namespace Esri::ArcGISRuntime::Authentication
 {
   class OAuthUserConfiguration;
   class OAuthUserLoginPrompt;
+  class OAuthUserLogoutPrompt;
   class ArcGISAuthenticationChallenge;
   class NetworkAuthenticationChallenge;
 } // namespace Esri::ArcGISRuntime::Authentication
@@ -42,6 +44,10 @@ namespace Esri::ArcGISRuntime::Toolkit
 
   class ArcGISAuthenticationChallengeRelay;
   class NetworkAuthenticationChallengeRelay;
+
+#ifdef Q_OS_IOS
+  class IOSWebAuthenticationSession;
+#endif
 
   class AuthenticatorController : public QObject
   {
@@ -75,9 +81,13 @@ namespace Esri::ArcGISRuntime::Toolkit
     // token authentication
     Q_INVOKABLE void continueWithUsernamePassword(const QString& username, const QString& password);
 
-    // OAuth
+    // OAuth (login)
     Q_INVOKABLE void respond(const QUrl& url);
     Q_INVOKABLE void respondWithError(const QString& platformError);
+
+    // OAuth (logout)
+    Q_INVOKABLE void logoutRespond(bool result);
+    Q_INVOKABLE void logoutRespondWithError(const QString& platformError);
 
     // ServerTrust
     Q_INVOKABLE void continueWithServerTrust(bool trust);
@@ -115,8 +125,12 @@ namespace Esri::ArcGISRuntime::Toolkit
     QString redirectUri_() const;
     int previousFailureCount_() const;
 
+    // login
     void processOAuthExternalBrowserLogin_();
-    void finishOAuthExternalBrowserChallengeFlow_();
+    // logout
+    void processOAuthExternalBrowserLogout_();
+    // login and logout
+    void finishOAuthExternalBrowserFlow_();
 
     void continueWithUsernamePasswordArcGIS_(const QString& username, const QString& password);
     void continueWithUsernamePasswordNetwork_(const QString& username, const QString& password);
@@ -129,6 +143,11 @@ namespace Esri::ArcGISRuntime::Toolkit
     QList<Esri::ArcGISRuntime::Authentication::OAuthUserConfiguration*> m_userConfigurations;
     Esri::ArcGISRuntime::Authentication::OAuthUserConfiguration* m_currentOAuthUserConfiguration = nullptr;
     std::unique_ptr<Authentication::OAuthUserLoginPrompt> m_currentOAuthUserLoginPrompt;
+    std::unique_ptr<Authentication::OAuthUserLogoutPrompt> m_currentOAuthUserLogoutPrompt;
+
+#ifdef Q_OS_IOS
+    std::unique_ptr<IOSWebAuthenticationSession> m_iosWebAuthenticationSession;
+#endif
 
     std::mutex m_mutex;
   };

--- a/uitools/common/src/AuthenticatorController.h
+++ b/uitools/common/src/AuthenticatorController.h
@@ -85,10 +85,6 @@ namespace Esri::ArcGISRuntime::Toolkit
     Q_INVOKABLE void respond(const QUrl& url);
     Q_INVOKABLE void respondWithError(const QString& platformError);
 
-    // OAuth (logout)
-    Q_INVOKABLE void logoutRespond(bool result);
-    Q_INVOKABLE void logoutRespondWithError(const QString& platformError);
-
     // ServerTrust
     Q_INVOKABLE void continueWithServerTrust(bool trust);
 

--- a/uitools/common/src/IOS/IOSWebAuthenticationSession.h
+++ b/uitools/common/src/IOS/IOSWebAuthenticationSession.h
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ *  Copyright 2012-2026 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+#ifndef ESRI_ARCGISRUNTIME_TOOLKIT_IOSWEBAUTHENTICATIONSESSION_H
+#define ESRI_ARCGISRUNTIME_TOOLKIT_IOSWEBAUTHENTICATIONSESSION_H
+
+// Qt headers
+#include <QObject>
+#include <QtGlobal>
+
+class QUrl;
+class QString;
+
+#ifdef Q_OS_IOS
+Q_FORWARD_DECLARE_OBJC_CLASS(ASWebAuthenticationSession);
+Q_FORWARD_DECLARE_OBJC_CLASS(NSObject);
+#endif
+
+namespace Esri::ArcGISRuntime::Toolkit
+{
+
+#ifdef Q_OS_IOS
+
+  class IOSWebAuthenticationSession : public QObject
+  {
+    Q_OBJECT
+  public:
+    explicit IOSWebAuthenticationSession(QObject* parent = nullptr);
+    ~IOSWebAuthenticationSession() override;
+
+    void start(const QUrl& authorizationUrl, const QString& callbackUrlScheme, bool prefersEphemeralWebBrowserSession = false);
+    void cancel();
+
+  signals:
+    void completed(const QUrl& callbackUrl);
+    void canceled();
+    void failed(const QString& error);
+
+  private:
+    ASWebAuthenticationSession* m_session = nullptr;
+    NSObject* m_presentationContextProvider = nullptr;
+  };
+
+#endif // Q_OS_IOS
+
+} // namespace Esri::ArcGISRuntime::Toolkit
+
+#endif // ESRI_ARCGISRUNTIME_TOOLKIT_IOSWEBAUTHENTICATIONSESSION_H

--- a/uitools/common/src/IOS/IOSWebAuthenticationSession.mm
+++ b/uitools/common/src/IOS/IOSWebAuthenticationSession.mm
@@ -62,10 +62,10 @@ namespace
   }
 } // namespace
 
-@interface QRTWebAuthPresentationContextProvider : NSObject<ASWebAuthenticationPresentationContextProviding>
+@interface QtWebAuthPresentationContextProvider : NSObject<ASWebAuthenticationPresentationContextProviding>
 @end
 
-@implementation QRTWebAuthPresentationContextProvider
+@implementation QtWebAuthPresentationContextProvider
 
 - (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:(ASWebAuthenticationSession*)session
 {
@@ -82,7 +82,7 @@ namespace Esri::ArcGISRuntime::Toolkit
   IOSWebAuthenticationSession::IOSWebAuthenticationSession(QObject* parent) :
     QObject(parent)
   {
-    m_presentationContextProvider = [[QRTWebAuthPresentationContextProvider alloc] init];
+    m_presentationContextProvider = [[QtWebAuthPresentationContextProvider alloc] init];
   }
 
   IOSWebAuthenticationSession::~IOSWebAuthenticationSession()

--- a/uitools/common/src/IOS/IOSWebAuthenticationSession.mm
+++ b/uitools/common/src/IOS/IOSWebAuthenticationSession.mm
@@ -1,0 +1,195 @@
+/*******************************************************************************
+ *  Copyright 2012-2026 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+
+#include "IOSWebAuthenticationSession.h"
+
+#ifdef Q_OS_IOS
+
+#import <AuthenticationServices/AuthenticationServices.h>
+#import <UIKit/UIKit.h>
+
+#include <QMetaObject>
+#include <QPointer>
+#include <QUrl>
+
+namespace
+{
+  static UIWindow* presentationWindow()
+  {
+    UIApplication* app = UIApplication.sharedApplication;
+
+    for (UIScene* scene in app.connectedScenes)
+    {
+      if (scene.activationState != UISceneActivationStateForegroundActive)
+      {
+        continue;
+      }
+
+      if (![scene isKindOfClass:[UIWindowScene class]])
+      {
+        continue;
+      }
+
+      UIWindowScene* windowScene = (UIWindowScene*)scene;
+      for (UIWindow* w in windowScene.windows)
+      {
+        if (w.isKeyWindow)
+        {
+          return w;
+        }
+      }
+
+      if (windowScene.windows.count > 0)
+      {
+        return windowScene.windows.firstObject;
+      }
+    }
+
+    return nil;
+  }
+} // namespace
+
+@interface QRTWebAuthPresentationContextProvider : NSObject<ASWebAuthenticationPresentationContextProviding>
+@end
+
+@implementation QRTWebAuthPresentationContextProvider
+
+- (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:(ASWebAuthenticationSession*)session
+{
+  Q_UNUSED(session);
+  UIWindow* w = presentationWindow();
+  return w ? w : (UIWindow*)nil;
+}
+
+@end
+
+namespace Esri::ArcGISRuntime::Toolkit
+{
+
+  IOSWebAuthenticationSession::IOSWebAuthenticationSession(QObject* parent) :
+    QObject(parent)
+  {
+    m_presentationContextProvider = [[QRTWebAuthPresentationContextProvider alloc] init];
+  }
+
+  IOSWebAuthenticationSession::~IOSWebAuthenticationSession()
+  {
+    cancel();
+
+    if (m_presentationContextProvider)
+    {
+      [m_presentationContextProvider release];
+      m_presentationContextProvider = nullptr;
+    }
+  }
+
+  void IOSWebAuthenticationSession::start(const QUrl& authorizationUrl, const QString& callbackUrlScheme, bool prefersEphemeralWebBrowserSession)
+  {
+    cancel();
+
+    const auto authUrlString = authorizationUrl.toString();
+    NSURL* url = [NSURL URLWithString:authUrlString.toNSString()];
+
+    if (!url)
+    {
+      emit failed(QStringLiteral("Invalid authorization URL"));
+      return;
+    }
+
+    const QString scheme = callbackUrlScheme.trimmed();
+    if (scheme.isEmpty())
+    {
+      emit failed(QStringLiteral("Redirect URI has no callback URL scheme"));
+      return;
+    }
+
+    QPointer<IOSWebAuthenticationSession> guard(this);
+    m_session =
+      [[ASWebAuthenticationSession alloc] initWithURL:url
+                                    callbackURLScheme:scheme.toNSString()
+                                    completionHandler:^(NSURL* _Nullable callbackURL, NSError* _Nullable error) {
+                                      if (!guard)
+                                      {
+                                        return;
+                                      }
+
+                                      IOSWebAuthenticationSession* self = guard.data();
+
+                                      if (error)
+                                      {
+                                        const bool canceledLogin = [error.domain isEqualToString:ASWebAuthenticationSessionErrorDomain] &&
+                                                                   error.code == ASWebAuthenticationSessionErrorCodeCanceledLogin;
+
+                                        const QString message = QString::fromNSString(error.localizedDescription);
+
+                                        QMetaObject::invokeMethod(self, [self, canceledLogin, message]()
+                                        {
+                                          if (canceledLogin)
+                                          {
+                                            emit self->canceled();
+                                          }
+                                          else
+                                          {
+                                            emit self->failed(message.isEmpty() ? QStringLiteral("ASWebAuthenticationSession failed") : message);
+                                          }
+                                        }, Qt::QueuedConnection);
+
+                                        return;
+                                      }
+
+                                      if (!callbackURL)
+                                      {
+                                        QMetaObject::invokeMethod(self, [self]()
+                                        {
+                                          emit self->failed(QStringLiteral("ASWebAuthenticationSession returned no callback URL"));
+                                        }, Qt::QueuedConnection);
+                                        return;
+                                      }
+
+                                      NSString* absoluteString = callbackURL.absoluteString;
+                                      const QUrl qtCallbackUrl{QString::fromNSString(absoluteString)};
+
+                                      QMetaObject::invokeMethod(self, [self, qtCallbackUrl]()
+                                      {
+                                        emit self->completed(qtCallbackUrl);
+                                      }, Qt::QueuedConnection);
+                                    }];
+
+    m_session.presentationContextProvider = (id<ASWebAuthenticationPresentationContextProviding>)m_presentationContextProvider;
+    m_session.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession;
+
+    const BOOL started = [m_session start];
+    if (!started)
+    {
+      emit failed(QStringLiteral("Unable to start ASWebAuthenticationSession"));
+      cancel();
+    }
+  }
+
+  void IOSWebAuthenticationSession::cancel()
+  {
+    if (m_session)
+    {
+      [m_session cancel];
+
+      [m_session release];
+      m_session = nullptr;
+    }
+  }
+
+} // namespace Esri::ArcGISRuntime::Toolkit
+
+#endif // Q_OS_IOS

--- a/uitools/toolkitcpp/CMakeLists.txt
+++ b/uitools/toolkitcpp/CMakeLists.txt
@@ -49,6 +49,12 @@ target_link_libraries(libtoolkitcpp PRIVATE
     ArcGISRuntime::Cpp
 )
 
+if(IOS)
+    target_link_libraries(libtoolkitcpp PRIVATE
+        ${ESRI_ARCGISRUNTIME_TOOLKIT_COMMON_IOS_FRAMEWORKS}
+    )
+endif()
+
 set(esri_arcgisruntime_toolkit_view_resource_files
     "import/Esri/ArcGISRuntime/Toolkit/AttachmentsPopupElementView.qml"
     "import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml"


### PR DESCRIPTION
This introduces new functionality for identity-aware proxy support, and a minor refactoring of the existing iOS OAuth logic to accommodate some quirks of the IAP workflows.

There are two main quirks of IAP that necessitated migrating to a native iOS implementation.
1. redirect URL matching.
2. IAP logout workflow shortcomings.

For the first issue, there are some issues discovered in testing IAP where Qt's auth APIs reject the redirect URL because the server does not respond with the exact match of what was requested. The new iOS implementation allows resiliency against that since it does not validate it.

For the second issue, iOS provides no "back button" navigation experience like Android does if you are sent over to Safari with no clean way back. The new iOS implementation shows Safari as a popup from within the same app session while still being out of process. This allows users to get back to the app cleanly.

## Summary of changes

 * New iOS OAuth backend to handle the browser experience.
 * New OAuth logout callbacks hooked up and enabled. This allows for signing out of IAP workflows.
 * Embedded browser logout is not implemented - if this happens the toolkit will immediately fail the request.
 * Both Android and iOS implementations of logout are basic. As mentioned, the callback mechanism does not work as expected (it cannot redirect to an app), so the logic assumes it is successful. That matches other SDK team's implementations.