### PR TITLE
Fix clang tidy warning

### DIFF
--- a/uitools/common/src/MediaPopupElementViewController.cpp
+++ b/uitools/common/src/MediaPopupElementViewController.cpp
@@ -57,8 +57,7 @@ namespace Esri::ArcGISRuntime::Toolkit
           m_popupMediaItems->append(new ImagePopupMediaItem(popupMedia, popupViewController, media));
           break;
         case Esri::ArcGISRuntime::PopupMediaType::BarChart:
-          m_popupMediaItems->append(new BarChartPopupMediaItem(popupMedia, media));
-          break;
+          [[fallthrough]];
         case Esri::ArcGISRuntime::PopupMediaType::ColumnChart:
           m_popupMediaItems->append(new BarChartPopupMediaItem(popupMedia, media));
           break;


### PR DESCRIPTION
https://releases.llvm.org/21.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/bugprone/branch-clone.html

I confirmed with @jared-2016 this logic is correct - both branches should use BarChartPopupMediaItem