### PR TITLE
Standardize OAuth system browser approach

### DIFF
--- a/uitools/common/src/AuthenticatorController.cpp
+++ b/uitools/common/src/AuthenticatorController.cpp
@@ -503,18 +503,14 @@ namespace Esri::ArcGISRuntime::Toolkit
 
     auto* callbackReplyHandler = new QOAuthUriSchemeReplyHandler(m_currentOAuthUserLoginPrompt.get());
 
-    connect(callbackReplyHandler, &QOAuthUriSchemeReplyHandler::callbackReceived, this, [this, oauthFlow](const QVariantMap& values)
+    connect(callbackReplyHandler, &QOAuthUriSchemeReplyHandler::callbackDataReceived, this,
+            [this, oauthFlow, callbackReplyHandler](const QByteArray& data)
     {
-      if (!values.contains("code"))
-      {
-        m_currentOAuthUserLoginPrompt->respondWithError("There was an error obtaining the authorization code");
-        finishOAuthExternalBrowserFlow_();
-        return;
-      }
+      callbackReplyHandler->close();
 
-      const auto code = values.value("code").toString();
-      oauthFlow->setAuthorizationCode(code);
+      m_currentOAuthUserLoginPrompt->respond(QUrl{data});
       emit oauthFlow->granted();
+      finishOAuthExternalBrowserFlow_();
     });
 
     oauthFlow->setAuthorizationUrl(m_currentOAuthUserLoginPrompt->authorizeUrl());
@@ -555,15 +551,6 @@ namespace Esri::ArcGISRuntime::Toolkit
     }();
 
     connect(oauthFlow, &QAbstractOAuth::authorizeWithBrowser, this, &QDesktopServices::openUrl);
-    connect(oauthFlow, &QAbstractOAuth::granted, this, [adjustedRedirectUri, callbackReplyHandler, oauthFlow, this]()
-    {
-      callbackReplyHandler->close();
-
-      // this needs to be in the form of redirectUri?code=authCode
-      const auto formattedResponseUrl = QUrl{QString("%1?code=%2").arg(adjustedRedirectUri, oauthFlow->authorizationCode())};
-      m_currentOAuthUserLoginPrompt->respond(formattedResponseUrl);
-      finishOAuthExternalBrowserFlow_();
-    });
 
     callbackReplyHandler->setRedirectUrl(adjustedRedirectUri);
     oauthFlow->setReplyHandler(callbackReplyHandler);

--- a/uitools/common/src/CustomOAuth2AuthorizationCodeFlow.cpp
+++ b/uitools/common/src/CustomOAuth2AuthorizationCodeFlow.cpp
@@ -36,14 +36,4 @@ namespace Esri::ArcGISRuntime::Toolkit
     emit authorizeWithBrowser(m_authorizeUrl);
   }
 
-  QString CustomOAuth2AuthorizationCodeFlow::authorizationCode() const
-  {
-    return m_authorizationCode;
-  }
-
-  void CustomOAuth2AuthorizationCodeFlow::setAuthorizationCode(const QString& code)
-  {
-    m_authorizationCode = code;
-  }
-
 } // namespace Esri::ArcGISRuntime::Toolkit

--- a/uitools/common/src/CustomOAuth2AuthorizationCodeFlow.h
+++ b/uitools/common/src/CustomOAuth2AuthorizationCodeFlow.h
@@ -32,13 +32,9 @@ namespace Esri::ArcGISRuntime::Toolkit
 
     void grant() override;
 
-    QString authorizationCode() const;
-    void setAuthorizationCode(const QString& code);
-
   private:
     Q_DISABLE_COPY_MOVE(CustomOAuth2AuthorizationCodeFlow)
 
-    QString m_authorizationCode;
     const QUrl m_authorizeUrl;
   };
 


### PR DESCRIPTION
Don't validate the incoming info, just pass it through.

Previously we did two steps:
1. `QOAuthUriSchemeReplyHandler::callbackReceived`, which only provides the parsed arguments from the browser session.
2. `QAbstractOAuth::granted`, where we need to reassemble the url with the code we parsed in the previous step.

We can simplify this by just using `QOAuthUriSchemeReplyHandler::callbackDataReceived` which has the info we're looking for to begin with.

This brings the Android implementation in line with the newer iOS implementation which just passes whatever the browser returned directly.