### PR TITLE
Update popup when AttributeListModel changes.

### DIFF
--- a/uitools/common/src/PopupViewController.cpp
+++ b/uitools/common/src/PopupViewController.cpp
@@ -46,6 +46,80 @@
 namespace Esri::ArcGISRuntime::Toolkit
 {
 
+  namespace
+  {
+    bool isReusableElementType(PopupElementType type)
+    {
+      return type == PopupElementType::TextPopupElement || type == PopupElementType::FieldsPopupElement;
+    }
+
+    PopupElementViewItem* popupElementViewItemAt(GenericListModel* model, int index)
+    {
+      auto* object = model->element(model->index(index, 0));
+      return qobject_cast<PopupElementViewItem*>(object);
+    }
+
+    bool canReuseControllersForElements(GenericListModel* model, const QList<PopupElement*>& evaluatedElements)
+    {
+      if (model->rowCount() != evaluatedElements.size())
+      {
+        return false;
+      }
+
+      for (int i = 0; i < evaluatedElements.size(); ++i)
+      {
+        auto* existingItem = popupElementViewItemAt(model, i);
+        const auto newType = evaluatedElements.at(i)->popupElementType();
+
+        if (!existingItem ||
+            existingItem->popupElementType() != static_cast<QmlEnums::PopupElementType>(newType) ||
+            !isReusableElementType(newType))
+        {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    void notifyControllerChanged(QObject* object, PopupElementType type)
+    {
+      switch (type)
+      {
+        case PopupElementType::TextPopupElement:
+          QMetaObject::invokeMethod(object, "textPopupElementChanged", Qt::DirectConnection);
+          break;
+        case PopupElementType::FieldsPopupElement:
+          QMetaObject::invokeMethod(object, "fieldsPopupElementChanged", Qt::DirectConnection);
+          break;
+        default:
+          break;
+      }
+    }
+
+    void appendControllerForElement(GenericListModel* model, PopupElement* element, PopupViewController* controller, Popup* popup)
+    {
+      switch (element->popupElementType())
+      {
+        case PopupElementType::TextPopupElement:
+          model->append(new TextPopupElementViewController(static_cast<TextPopupElement*>(element), controller, popup));
+          break;
+        case PopupElementType::FieldsPopupElement:
+          model->append(new FieldsPopupElementViewController(static_cast<FieldsPopupElement*>(element), controller, popup));
+          break;
+        case PopupElementType::AttachmentsPopupElement:
+          model->append(new AttachmentsPopupElementViewController(static_cast<AttachmentsPopupElement*>(element), controller, popup));
+          break;
+        case PopupElementType::MediaPopupElement:
+          model->append(new MediaPopupElementViewController(static_cast<MediaPopupElement*>(element), controller, popup));
+          break;
+        default:
+          Q_UNIMPLEMENTED();
+          break;
+      }
+    }
+  } // namespace
+
   /*!
     \internal
     This class is an internal implementation detail and is subject to change.
@@ -87,8 +161,6 @@ namespace Esri::ArcGISRuntime::Toolkit
       return;
     }
 
-    m_popupElementControllerModel->removeRows(0, m_popupElementControllerModel->rowCount());
-
     m_popup->evaluateExpressionsAsync(this).then(this, [this](const QList<PopupExpressionEvaluation*>&)
     {
       if (!m_popup)
@@ -96,26 +168,28 @@ namespace Esri::ArcGISRuntime::Toolkit
         return;
       }
 
-      for (auto element : m_popup->evaluatedElements())
+      const auto evaluatedElements = m_popup->evaluatedElements();
+      const bool canReuseControllers = canReuseControllersForElements(m_popupElementControllerModel, evaluatedElements);
+
+      if (canReuseControllers)
       {
-        switch (element->popupElementType())
+        for (int i = 0; i < evaluatedElements.size(); ++i)
         {
-          case Esri::ArcGISRuntime::PopupElementType::TextPopupElement:
-            m_popupElementControllerModel->append(new TextPopupElementViewController(static_cast<TextPopupElement*>(element), this, m_popup));
-            break;
-          case Esri::ArcGISRuntime::PopupElementType::FieldsPopupElement:
-            m_popupElementControllerModel->append(new FieldsPopupElementViewController(static_cast<FieldsPopupElement*>(element), this, m_popup));
-            break;
-          case Esri::ArcGISRuntime::PopupElementType::AttachmentsPopupElement:
-            m_popupElementControllerModel->append(
-              new AttachmentsPopupElementViewController(static_cast<AttachmentsPopupElement*>(element), this, m_popup));
-            break;
-          case Esri::ArcGISRuntime::PopupElementType::MediaPopupElement:
-            m_popupElementControllerModel->append(new MediaPopupElementViewController(static_cast<MediaPopupElement*>(element), this, m_popup));
-            break;
-          default:
-            Q_UNIMPLEMENTED();
-            break;
+          auto* existingObject = m_popupElementControllerModel->element(m_popupElementControllerModel->index(i, 0));
+          auto* existingItem = popupElementViewItemAt(m_popupElementControllerModel, i);
+          auto* newElement = evaluatedElements.at(i);
+
+          existingItem->setPopupElement(newElement);
+          notifyControllerChanged(existingObject, newElement->popupElementType());
+        }
+      }
+      else
+      {
+        m_popupElementControllerModel->removeRows(0, m_popupElementControllerModel->rowCount());
+
+        for (auto* const element : evaluatedElements)
+        {
+          appendControllerForElement(m_popupElementControllerModel, element, this, m_popup);
         }
       }
 

--- a/uitools/common/src/PopupViewController.cpp
+++ b/uitools/common/src/PopupViewController.cpp
@@ -93,6 +93,7 @@ namespace Esri::ArcGISRuntime::Toolkit
           QMetaObject::invokeMethod(object, "fieldsPopupElementChanged", Qt::DirectConnection);
           break;
         default:
+          Q_UNIMPLEMENTED();
           break;
       }
     }

--- a/uitools/common/src/PopupViewController.cpp
+++ b/uitools/common/src/PopupViewController.cpp
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  *  Copyright 2012-2020 Esri
  *
@@ -26,7 +25,9 @@
 
 // Maps SDK headers
 #include "AttachmentsPopupElement.h"
+#include "AttributeListModel.h"
 #include "FieldsPopupElement.h"
+#include "GeoElement.h"
 #include "MediaPopupElement.h"
 #include "Popup.h"
 #include "PopupDefinition.h"
@@ -70,28 +71,31 @@ namespace Esri::ArcGISRuntime::Toolkit
     return m_popupElementControllerModel;
   }
 
-  void PopupViewController::setPopup(Popup* popup)
+  void PopupViewController::disconnectAttributeModelSignal_()
   {
-    if (m_popup == popup)
+    if (m_attributeModelConnection)
+    {
+      disconnect(m_attributeModelConnection);
+      m_attributeModelConnection = {};
+    }
+  }
+
+  void PopupViewController::refreshPopupContent_()
+  {
+    if (!m_popup)
     {
       return;
     }
 
-    if (m_popup)
-    {
-      disconnect(m_popup.data(), nullptr, this, nullptr);
-      m_popupElementControllerModel->removeRows(0, m_popupElementControllerModel->rowCount());
-    }
-
-    m_popup = popup;
-
-    if (m_popup)
-    {
-      connect(m_popup.data(), &QObject::destroyed, this, &PopupViewController::popupChanged);
-    }
+    m_popupElementControllerModel->removeRows(0, m_popupElementControllerModel->rowCount());
 
     m_popup->evaluateExpressionsAsync(this).then(this, [this](const QList<PopupExpressionEvaluation*>&)
     {
+      if (!m_popup)
+      {
+        return;
+      }
+
       for (auto element : m_popup->evaluatedElements())
       {
         switch (element->popupElementType())
@@ -114,8 +118,48 @@ namespace Esri::ArcGISRuntime::Toolkit
             break;
         }
       }
+
       emit popupChanged();
+      emit titleChanged();
+      emit editSummaryChanged();
     });
+  }
+
+  void PopupViewController::setPopup(Popup* popup)
+  {
+    if (m_popup == popup)
+    {
+      return;
+    }
+
+    if (m_popup)
+    {
+      disconnect(m_popup.data(), nullptr, this, nullptr);
+      disconnectAttributeModelSignal_();
+      m_popupElementControllerModel->removeRows(0, m_popupElementControllerModel->rowCount());
+    }
+
+    m_popup = popup;
+
+    if (m_popup)
+    {
+      connect(m_popup.data(), &QObject::destroyed, this, &PopupViewController::popupChanged);
+
+      if (auto* geoElement = m_popup->geoElement())
+      {
+        if (auto* attributes = geoElement->attributes())
+        {
+          // AttributeListModel currently forwards streamed attribute updates as begin/endResetModel, so we listen for model reset only.
+          // If the attributes model starts emitting more fine grained signals for attribute updates in the future, this can be updated to listen for those.
+          m_attributeModelConnection = connect(attributes, &QAbstractItemModel::modelReset, this, [this]()
+          {
+            refreshPopupContent_();
+          });
+        }
+      }
+    }
+
+    refreshPopupContent_();
 
     emit popupChanged();
     emit titleChanged();

--- a/uitools/common/src/PopupViewController.h
+++ b/uitools/common/src/PopupViewController.h
@@ -18,6 +18,7 @@
 
 // Qt headers
 #include <QAbstractListModel>
+#include <QMetaObject>
 #include <QObject>
 #include <QPointer>
 
@@ -72,8 +73,12 @@ namespace Esri::ArcGISRuntime
       void imageClicked(const QUrl& sourceUrl, const QUrl& linkUrl);
 
     private:
+      void refreshPopupContent_();
+      void disconnectAttributeModelSignal_();
+
       QPointer<Popup> m_popup;
       GenericListModel* m_popupElementControllerModel = nullptr;
+      QMetaObject::Connection m_attributeModelConnection;
     };
 
   } // namespace Toolkit


### PR DESCRIPTION
The following changes have been made in this PR:

- Added `refreshPopupContent_` private function to update popup.
- When Popup is set in the controller we additionally listen for changes to the `AttributeListModel` to update popup.

Instead of recreating controllers to update view on every refresh, the order of the views are checked to see if we can update them instead. Updating the individual views instead of recreating them prevents the scrollview from being reset.