### PR TITLE
Cancel outstanding challenges.

### DIFF
--- a/uitools/common/src/AuthenticatorController.cpp
+++ b/uitools/common/src/AuthenticatorController.cpp
@@ -124,6 +124,22 @@ namespace Esri::ArcGISRuntime::Toolkit
 
   AuthenticatorController::~AuthenticatorController() = default;
 
+  void AuthenticatorController::cancelOutstandingChallenges()
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_currentNetworkChallenge)
+    {
+      m_currentNetworkChallenge->cancel();
+      m_currentNetworkChallenge.reset();
+    }
+
+    if (m_currentArcGISChallenge)
+    {
+      m_currentArcGISChallenge->cancel();
+      m_currentArcGISChallenge.reset();
+    }
+  }
+
   AuthenticatorController* AuthenticatorController::create(QQmlEngine* qmlEngine, QJSEngine* /*jsEngine*/)
   {
     static QPointer<AuthenticatorController> instance = new AuthenticatorController(qmlEngine);

--- a/uitools/common/src/AuthenticatorController.h
+++ b/uitools/common/src/AuthenticatorController.h
@@ -69,6 +69,9 @@ namespace Esri::ArcGISRuntime::Toolkit
 
     ~AuthenticatorController() override;
 
+    // for when users abandon a challenge view without responding (e.g. back button, app switch, etc.)
+    void cancelOutstandingChallenges();
+
     enum class CertificateResult
     {
       Accepted,


### PR DESCRIPTION
Ideally the controller can detect this automatically, but there are too many edge cases to be confident
we can do it correctly and not misinterpret what actually happened.

For now, we will allow consuming code to call this when appropriate. I did not add any logic for the OAuth login/logout prompts, because abandoning those workflows would be more complicated to detect since they can be out of process.