### PR TITLE
Add support for refresh intervals for PopupMedia Images(PopupElements)

### DIFF
--- a/uitools/common/src/ImagePopupMediaItem.cpp
+++ b/uitools/common/src/ImagePopupMediaItem.cpp
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  *  Copyright 2012-2025 Esri
  *
@@ -42,7 +41,10 @@ namespace Esri::ArcGISRuntime::Toolkit
     connect(this, &ImagePopupMediaItem::imagePopupMediaItemChanged, this, &ImagePopupMediaItem::setupRefreshTimer);
   }
 
-  ImagePopupMediaItem::~ImagePopupMediaItem() = default;
+  ImagePopupMediaItem::~ImagePopupMediaItem()
+  {
+    m_refreshTimer.stop();
+  }
 
   QUrl ImagePopupMediaItem::sourceUrl() const
   {

--- a/uitools/common/src/ImagePopupMediaItem.cpp
+++ b/uitools/common/src/ImagePopupMediaItem.cpp
@@ -50,4 +50,9 @@ namespace Esri::ArcGISRuntime::Toolkit
     return popupMediaItem()->value()->linkUrl();
   }
 
+  quint64 ImagePopupMediaItem::imageRefreshInterval() const
+  {
+    return popupMediaItem()->imageRefreshInterval();
+  }
+
 } // namespace Esri::ArcGISRuntime::Toolkit

--- a/uitools/common/src/ImagePopupMediaItem.cpp
+++ b/uitools/common/src/ImagePopupMediaItem.cpp
@@ -36,6 +36,10 @@ namespace Esri::ArcGISRuntime::Toolkit
   {
     // bubble up imageClicked signal to PopupViewController. This is the sourceUrl & linkUrl used for ImagePopupMediaItems.
     connect(this, &ImagePopupMediaItem::imageClicked, popupViewController, &PopupViewController::imageClicked);
+
+    setupRefreshTimer();
+
+    connect(this, &ImagePopupMediaItem::imagePopupMediaItemChanged, this, &ImagePopupMediaItem::setupRefreshTimer);
   }
 
   ImagePopupMediaItem::~ImagePopupMediaItem() = default;
@@ -53,6 +57,20 @@ namespace Esri::ArcGISRuntime::Toolkit
   quint64 ImagePopupMediaItem::imageRefreshInterval() const
   {
     return popupMediaItem()->imageRefreshInterval();
+  }
+
+  void ImagePopupMediaItem::setupRefreshTimer()
+  {
+    m_refreshTimer.stop();
+
+    const quint64 interval = imageRefreshInterval();
+    if (interval > 0)
+    {
+      m_refreshTimer.setInterval(static_cast<int>(interval));
+      m_refreshTimer.setSingleShot(false);
+      connect(&m_refreshTimer, &QTimer::timeout, this, &ImagePopupMediaItem::refreshImage, Qt::UniqueConnection);
+      m_refreshTimer.start();
+    }
   }
 
 } // namespace Esri::ArcGISRuntime::Toolkit

--- a/uitools/common/src/ImagePopupMediaItem.cpp
+++ b/uitools/common/src/ImagePopupMediaItem.cpp
@@ -43,7 +43,10 @@ namespace Esri::ArcGISRuntime::Toolkit
 
   ImagePopupMediaItem::~ImagePopupMediaItem()
   {
-    m_refreshTimer.stop();
+    if (m_refreshTimer.isActive())
+    {
+      m_refreshTimer.stop();
+    }
   }
 
   QUrl ImagePopupMediaItem::sourceUrl() const

--- a/uitools/common/src/ImagePopupMediaItem.h
+++ b/uitools/common/src/ImagePopupMediaItem.h
@@ -19,6 +19,7 @@
 // Qt headers
 #include <QJsonObject>
 #include <QObject>
+#include <QTimer>
 
 // Other headers
 #include "PopupMediaItem.h"
@@ -44,9 +45,13 @@ namespace Esri::ArcGISRuntime::Toolkit
     QUrl sourceUrl() const;
     quint64 imageRefreshInterval() const;
 
+    void setupRefreshTimer();
+    QTimer m_refreshTimer;
+
   signals:
     void imagePopupMediaItemChanged();
     void imageClicked(const QUrl& sourceUrl, const QUrl& linkUrl);
+    void refreshImage();
   };
 
 } // namespace Esri::ArcGISRuntime::Toolkit

--- a/uitools/common/src/ImagePopupMediaItem.h
+++ b/uitools/common/src/ImagePopupMediaItem.h
@@ -33,6 +33,7 @@ namespace Esri::ArcGISRuntime::Toolkit
     Q_OBJECT
     Q_PROPERTY(QUrl sourceUrl READ sourceUrl NOTIFY imagePopupMediaItemChanged)
     Q_PROPERTY(QUrl linkUrl READ linkUrl NOTIFY imagePopupMediaItemChanged)
+    Q_PROPERTY(quint64 imageRefreshInterval READ imageRefreshInterval NOTIFY imagePopupMediaItemChanged)
 
   public:
     explicit ImagePopupMediaItem(PopupMedia* popupMedia, PopupViewController* popupViewController, QObject* parent = nullptr);
@@ -41,6 +42,7 @@ namespace Esri::ArcGISRuntime::Toolkit
   private:
     QUrl linkUrl() const;
     QUrl sourceUrl() const;
+    quint64 imageRefreshInterval() const;
 
   signals:
     void imagePopupMediaItemChanged();

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/MediaPopupElementView.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/MediaPopupElementView.qml
@@ -257,8 +257,6 @@ ColumnLayout {
                         border.color: palette.dark
                         border.width: 1
 
-
-
                         Text {
                             text: qsTr("Image unavailable")
                             color: palette.text

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/MediaPopupElementView.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/MediaPopupElementView.qml
@@ -206,35 +206,86 @@ ColumnLayout {
 
             Component.onCompleted: {
                 switch (popupMediaType) {
-                    case QmlEnums.PopupMediaTypeImage:
-                        mediaLoader.sourceComponent = imageComp;
-                        break;
-                    case QmlEnums.PopupMediaTypeColumnChart:
-                        mediaLoader.sourceComponent = columnChartComp;
-                        break;
-                    case QmlEnums.PopupMediaTypeBarChart:
-                        mediaLoader.sourceComponent = barChartComp;
-                        break;
-                    case QmlEnums.PopupMediaTypePieChart:
-                        mediaLoader.sourceComponent = pieChartComp;
-                        break;
-                    case QmlEnums.PopupMediaTypeLineChart:
-                        mediaLoader.sourceComponent = lineChartComp;
-                        break;
+                case QmlEnums.PopupMediaTypeImage:
+                    mediaLoader.sourceComponent = imageComp;
+                    break;
+                case QmlEnums.PopupMediaTypeColumnChart:
+                    mediaLoader.sourceComponent = columnChartComp;
+                    break;
+                case QmlEnums.PopupMediaTypeBarChart:
+                    mediaLoader.sourceComponent = barChartComp;
+                    break;
+                case QmlEnums.PopupMediaTypePieChart:
+                    mediaLoader.sourceComponent = pieChartComp;
+                    break;
+                case QmlEnums.PopupMediaTypeLineChart:
+                    mediaLoader.sourceComponent = lineChartComp;
+                    break;
                 }
             }
 
             Component {
                 id: imageComp
                 Image {
-                    source: listModelData.sourceUrl
+                    id: popupImage
+                    property url currentSourceUrl: listModelData.sourceUrl
+                    property bool hasLoggedImageError: false
+                    source: currentSourceUrl
                     fillMode: fullScreenImageDialog.visible ? Image.PreserveAspectFit : Image.PreserveAspectCrop
                     asynchronous: true
-                    cache: true
+                    // Disable cache when refresh interval is set so timed reloads fetch updated content.
+                    cache: listModelData.imageRefreshInterval === 0
                     height: delegatePopupMedia.height
                     width: delegatePopupMedia.width
 
                     Layout.leftMargin: mediaPopupElementView.mediaMargin
+
+                    onStatusChanged: {
+                        if (status === Image.Error && !hasLoggedImageError) {
+                            console.warn("Failed to load popup image from source:", currentSourceUrl);
+                            hasLoggedImageError = true;
+                        } else if (status === Image.Ready) {
+                            hasLoggedImageError = false;
+                        }
+                    }
+
+                    // Image fallback
+                    Rectangle {
+                        anchors.fill: parent
+                        visible: popupImage.status === Image.Error
+                        color: palette.base
+                        border.color: palette.dark
+                        border.width: 1
+
+
+
+                        Text {
+                            text: qsTr("Image unavailable")
+                            color: palette.text
+                            anchors.centerIn: parent
+                            anchors.verticalCenterOffset: -15
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                    }
+
+                    Connections {
+                        target: listModelData
+
+                        function onImagePopupMediaItemChanged() {
+                            popupImage.currentSourceUrl = listModelData.sourceUrl;
+                        }
+                    }
+
+                    Timer {
+                        running: listModelData.imageRefreshInterval > 0
+                        repeat: true
+                        interval: listModelData.imageRefreshInterval
+                        onTriggered: {
+                            popupImage.currentSourceUrl = "";
+                            popupImage.currentSourceUrl = listModelData.sourceUrl;
+                        }
+                    }
                 }
             }
 
@@ -281,19 +332,19 @@ ColumnLayout {
                         }
 
                         onHoverEnter: (name, position, value) => {
-                            columnPopup.visible = true;
-                            // adding in offsets so the popup is above the cursor
-                            columnPopup.x = position.x + 40;
-                            columnPopup.y = position.y - 20;
-                            columnLabelText.text = value.y;
-                        }
+                                          columnPopup.visible = true;
+                                          // adding in offsets so the popup is above the cursor
+                                          columnPopup.x = position.x + 40;
+                                          columnPopup.y = position.y - 20;
+                                          columnLabelText.text = value.y;
+                                      }
 
                         onHover: (name, position, value) => {
-                            // adding in offsets so the popup is above the cursor
-                            columnPopup.x = position.x + 40;
-                            columnPopup.y = position.y - 20;
-                            columnLabelText.text = value.y;
-                        }
+                                     // adding in offsets so the popup is above the cursor
+                                     columnPopup.x = position.x + 40;
+                                     columnPopup.y = position.y - 20;
+                                     columnLabelText.text = value.y;
+                                 }
 
                         onHoverExit: {
                             columnPopup.visible = false;
@@ -371,19 +422,19 @@ ColumnLayout {
                         }
 
                         onHoverEnter: (name, position, value) => {
-                            barPopup.visible = true;
-                            // adding in offsets so the popup is above the cursor
-                            barPopup.x = position.x;
-                            barPopup.y = position.y - 20;
-                            barPopupText.text = value.y;
-                        }
+                                          barPopup.visible = true;
+                                          // adding in offsets so the popup is above the cursor
+                                          barPopup.x = position.x;
+                                          barPopup.y = position.y - 20;
+                                          barPopupText.text = value.y;
+                                      }
 
                         onHover: (name, position, value) => {
-                            // adding in offsets so the popup is above the cursor
-                            barPopup.x = position.x;
-                            barPopup.y = position.y -20;
-                            barPopupText.text = value.y;
-                        }
+                                     // adding in offsets so the popup is above the cursor
+                                     barPopup.x = position.x;
+                                     barPopup.y = position.y -20;
+                                     barPopupText.text = value.y;
+                                 }
 
                         onHoverExit: {
                             barPopup.visible = false;
@@ -456,19 +507,19 @@ ColumnLayout {
                         }
 
                         onHoverEnter: (name, position, value) => {
-                            piePopup.visible = true;
-                            // adding in offsets so the popup is above the cursor
-                            piePopup.x = position.x;
-                            piePopup.y = position.y - 20;
-                            piePopupText.text = value.y;
-                        }
+                                          piePopup.visible = true;
+                                          // adding in offsets so the popup is above the cursor
+                                          piePopup.x = position.x;
+                                          piePopup.y = position.y - 20;
+                                          piePopupText.text = value.y;
+                                      }
 
                         onHover: (name, position, value) => {
-                            // adding in offsets so the popup is above the cursor
-                            piePopup.x = position.x;
-                            piePopup.y = position.y - 20;
-                            piePopupText.text = value.y;
-                        }
+                                     // adding in offsets so the popup is above the cursor
+                                     piePopup.x = position.x;
+                                     piePopup.y = position.y - 20;
+                                     piePopupText.text = value.y;
+                                 }
 
                         onHoverExit: {
                             piePopup.visible = false;
@@ -539,19 +590,19 @@ ColumnLayout {
                         }
 
                         onHoverEnter: (name, position, value) => {
-                            linePopup.visible = true;
-                            // adding in offsets so the popup is above the cursor
-                            linePopup.x = position.x;
-                            linePopup.y = position.y - 20;
-                            linePopupText.text = value.y;
-                        }
+                                          linePopup.visible = true;
+                                          // adding in offsets so the popup is above the cursor
+                                          linePopup.x = position.x;
+                                          linePopup.y = position.y - 20;
+                                          linePopupText.text = value.y;
+                                      }
 
                         onHover: (name, position, value) => {
-                            // adding in offsets so the popup is above the cursor
-                            linePopup.x = position.x;
-                            linePopup.y = position.y - 20;
-                            linePopupText.text = value.y;
-                        }
+                                     // adding in offsets so the popup is above the cursor
+                                     linePopup.x = position.x;
+                                     linePopup.y = position.y - 20;
+                                     linePopupText.text = value.y;
+                                 }
 
                         onHoverExit: {
                             linePopup.visible = false;

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/MediaPopupElementView.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/MediaPopupElementView.qml
@@ -228,9 +228,8 @@ ColumnLayout {
                 id: imageComp
                 Image {
                     id: popupImage
-                    property url currentSourceUrl: listModelData.sourceUrl
                     property bool hasLoggedImageError: false
-                    source: currentSourceUrl
+                    source: listModelData.sourceUrl
                     fillMode: fullScreenImageDialog.visible ? Image.PreserveAspectFit : Image.PreserveAspectCrop
                     asynchronous: true
                     // Disable cache when refresh interval is set so timed reloads fetch updated content.
@@ -242,7 +241,7 @@ ColumnLayout {
 
                     onStatusChanged: {
                         if (status === Image.Error && !hasLoggedImageError) {
-                            console.warn("Failed to load popup image from source:", currentSourceUrl);
+                            console.warn("Failed to load popup image from source:", popupImage.source);
                             hasLoggedImageError = true;
                         } else if (status === Image.Ready) {
                             hasLoggedImageError = false;
@@ -270,18 +269,9 @@ ColumnLayout {
                     Connections {
                         target: listModelData
 
-                        function onImagePopupMediaItemChanged() {
-                            popupImage.currentSourceUrl = listModelData.sourceUrl;
-                        }
-                    }
-
-                    Timer {
-                        running: listModelData.imageRefreshInterval > 0
-                        repeat: true
-                        interval: listModelData.imageRefreshInterval
-                        onTriggered: {
-                            popupImage.currentSourceUrl = "";
-                            popupImage.currentSourceUrl = listModelData.sourceUrl;
+                        function onRefreshImage() {
+                            popupImage.source = "";
+                            popupImage.source = listModelData.sourceUrl;
                         }
                     }
                 }


### PR DESCRIPTION
This PR adds refresh interval support for PopupMedia Images. A fallback has also been added when an image fails to load.

Note: - In `MediaPopupElementView.qml`, only the `imageComp` control has been modified to add a timer and an image fallback. The other diffs are from `cmd+i` indent.