### PR TITLE
QFuture state alone is not enough to prevent a feedback loop

### DIFF
--- a/uitools/common/src/OverviewMapController.cpp
+++ b/uitools/common/src/OverviewMapController.cpp
@@ -322,7 +322,22 @@ namespace Esri::ArcGISRuntime::Toolkit
 
   bool OverviewMapController::shouldApplyNavigationUpdate(GeoView* geoView) const
   {
-    return geoView && geoView->isNavigating() && !m_isUpdatingGeoViewFromInset && !m_isUpdatingInsetFromGeoView;
+    if (!geoView || !geoView->isNavigating())
+    {
+      return false;
+    }
+
+    if (geoView == m_geoView)
+    {
+      return !m_isUpdatingGeoViewFromInset;
+    }
+
+    if (geoView == m_insetView)
+    {
+      return !m_isUpdatingInsetFromGeoView;
+    }
+
+    return !m_isUpdatingGeoViewFromInset && !m_isUpdatingInsetFromGeoView;
   }
 
   void OverviewMapController::resetNavigationSynchronization()

--- a/uitools/common/src/OverviewMapController.cpp
+++ b/uitools/common/src/OverviewMapController.cpp
@@ -82,7 +82,7 @@ namespace Esri::ArcGISRuntime::Toolkit
     // to the main GeoView if applicable.
     connect(m_insetView, &MapViewToolkit::viewpointChanged, this, [this]
     {
-      if (shouldApplyNavigationUpdate(m_insetView))
+      if (m_insetView->isNavigating() && !m_isUpdatingInsetFromGeoView)
       {
         if (auto* sceneView = qobject_cast<SceneViewToolkit*>(m_geoView))
         {
@@ -156,7 +156,7 @@ namespace Esri::ArcGISRuntime::Toolkit
       {
         const Viewpoint viewpoint = sceneView->currentViewpoint(ViewpointType::CenterAndScale);
         m_reticle->setGeometry(viewpoint.targetGeometry());
-        if (shouldApplyNavigationUpdate(sceneView))
+        if (sceneView->isNavigating() && !m_isUpdatingGeoViewFromInset)
         {
           applySceneNavigationToInset(sceneView);
         }
@@ -200,7 +200,7 @@ namespace Esri::ArcGISRuntime::Toolkit
       {
         const Viewpoint viewpoint = localSceneView->currentViewpoint(ViewpointType::CenterAndScale);
         m_reticle->setGeometry(viewpoint.targetGeometry());
-        if (shouldApplyNavigationUpdate(localSceneView))
+        if (localSceneView->isNavigating() && !m_isUpdatingGeoViewFromInset)
         {
           applyLocalSceneNavigationToInset(localSceneView);
         }
@@ -246,7 +246,7 @@ namespace Esri::ArcGISRuntime::Toolkit
       QObject::connect(mapView, &MapViewToolkit::viewpointChanged, this, [this, mapView]
       {
         m_reticle->setGeometry(mapView->visibleArea());
-        if (shouldApplyNavigationUpdate(mapView))
+        if (mapView->isNavigating() && !m_isUpdatingGeoViewFromInset)
         {
           applyMapNavigationToInset(mapView);
         }
@@ -318,26 +318,6 @@ namespace Esri::ArcGISRuntime::Toolkit
     {
       emit mapView->viewpointChanged();
     }
-  }
-
-  bool OverviewMapController::shouldApplyNavigationUpdate(GeoView* geoView) const
-  {
-    if (!geoView || !geoView->isNavigating())
-    {
-      return false;
-    }
-
-    if (geoView == qobject_cast<GeoView*>(m_geoView))
-    {
-      return !m_isUpdatingGeoViewFromInset;
-    }
-
-    if (geoView == qobject_cast<GeoView*>(m_insetView))
-    {
-      return !m_isUpdatingInsetFromGeoView;
-    }
-
-    return !m_isUpdatingGeoViewFromInset && !m_isUpdatingInsetFromGeoView;
   }
 
   void OverviewMapController::resetNavigationSynchronization()

--- a/uitools/common/src/OverviewMapController.cpp
+++ b/uitools/common/src/OverviewMapController.cpp
@@ -327,12 +327,12 @@ namespace Esri::ArcGISRuntime::Toolkit
       return false;
     }
 
-    if (geoView == m_geoView)
+    if (geoView == qobject_cast<GeoView*>(m_geoView))
     {
       return !m_isUpdatingGeoViewFromInset;
     }
 
-    if (geoView == m_insetView)
+    if (geoView == qobject_cast<GeoView*>(m_insetView))
     {
       return !m_isUpdatingInsetFromGeoView;
     }

--- a/uitools/common/src/OverviewMapController.cpp
+++ b/uitools/common/src/OverviewMapController.cpp
@@ -57,6 +57,15 @@ namespace Esri::ArcGISRuntime::Toolkit
     m_insetView(new MapViewToolkit),
     m_reticle(new Graphic(this))
   {
+    connect(&m_setViewpointWatcher, &QFutureWatcher<bool>::finished, this, [this]
+    {
+      m_isUpdatingGeoViewFromInset = false;
+    });
+    connect(&m_setViewpointInsetWatcher, &QFutureWatcher<bool>::finished, this, [this]
+    {
+      m_isUpdatingInsetFromGeoView = false;
+    });
+
     m_insetView->setAttributionTextVisible(false);
 
     // Disable keyboard interactions, and mouse
@@ -73,7 +82,7 @@ namespace Esri::ArcGISRuntime::Toolkit
     // to the main GeoView if applicable.
     connect(m_insetView, &MapViewToolkit::viewpointChanged, this, [this]
     {
-      if (m_insetView->isNavigating() && !m_setViewpointFuture.isRunning())
+      if (shouldApplyNavigationUpdate(m_insetView))
       {
         if (auto* sceneView = qobject_cast<SceneViewToolkit*>(m_geoView))
         {
@@ -107,6 +116,8 @@ namespace Esri::ArcGISRuntime::Toolkit
     {
       return;
     }
+
+    resetNavigationSynchronization();
 
     if (m_geoView)
     {
@@ -145,7 +156,7 @@ namespace Esri::ArcGISRuntime::Toolkit
       {
         const Viewpoint viewpoint = sceneView->currentViewpoint(ViewpointType::CenterAndScale);
         m_reticle->setGeometry(viewpoint.targetGeometry());
-        if (sceneView->isNavigating() && !m_setViewpointInsetFuture.isRunning())
+        if (shouldApplyNavigationUpdate(sceneView))
         {
           applySceneNavigationToInset(sceneView);
         }
@@ -189,7 +200,7 @@ namespace Esri::ArcGISRuntime::Toolkit
       {
         const Viewpoint viewpoint = localSceneView->currentViewpoint(ViewpointType::CenterAndScale);
         m_reticle->setGeometry(viewpoint.targetGeometry());
-        if (localSceneView->isNavigating() && !m_setViewpointInsetFuture.isRunning())
+        if (shouldApplyNavigationUpdate(localSceneView))
         {
           applyLocalSceneNavigationToInset(localSceneView);
         }
@@ -235,7 +246,7 @@ namespace Esri::ArcGISRuntime::Toolkit
       QObject::connect(mapView, &MapViewToolkit::viewpointChanged, this, [this, mapView]
       {
         m_reticle->setGeometry(mapView->visibleArea());
-        if (mapView->isNavigating() && !m_setViewpointInsetFuture.isRunning())
+        if (shouldApplyNavigationUpdate(mapView))
         {
           applyMapNavigationToInset(mapView);
         }
@@ -309,6 +320,29 @@ namespace Esri::ArcGISRuntime::Toolkit
     }
   }
 
+  bool OverviewMapController::shouldApplyNavigationUpdate(GeoView* geoView) const
+  {
+    return geoView && geoView->isNavigating() && !m_isUpdatingGeoViewFromInset && !m_isUpdatingInsetFromGeoView;
+  }
+
+  void OverviewMapController::resetNavigationSynchronization()
+  {
+    m_isUpdatingGeoViewFromInset = false;
+    m_isUpdatingInsetFromGeoView = false;
+  }
+
+  void OverviewMapController::startGeoViewNavigationUpdate(const QFuture<bool>& future)
+  {
+    m_isUpdatingGeoViewFromInset = true;
+    m_setViewpointWatcher.setFuture(future);
+  }
+
+  void OverviewMapController::startInsetNavigationUpdate(const QFuture<bool>& future)
+  {
+    m_isUpdatingInsetFromGeoView = true;
+    m_setViewpointInsetWatcher.setFuture(future);
+  }
+
   void OverviewMapController::applyInsetNavigationToMapView(MapViewToolkit* view)
   {
     // Note we care about rotation in the mapView case.
@@ -316,7 +350,7 @@ namespace Esri::ArcGISRuntime::Toolkit
     const Viewpoint newViewpoint{geometry_cast<Point>(viewpoint.targetGeometry()), viewpoint.targetScale() / scaleFactor(), viewpoint.rotation()};
 
     constexpr float animationDuration{0};
-    m_setViewpointFuture = view->setViewpointAsync(newViewpoint, animationDuration);
+    startGeoViewNavigationUpdate(view->setViewpointAsync(newViewpoint, animationDuration));
   }
 
   void OverviewMapController::applyInsetNavigationToSceneView(SceneViewToolkit* view)
@@ -326,7 +360,7 @@ namespace Esri::ArcGISRuntime::Toolkit
     const Viewpoint newViewpoint{geometry_cast<Point>(viewpoint.targetGeometry()), viewpoint.targetScale() / scaleFactor()};
 
     constexpr float animationDuration{0};
-    m_setViewpointFuture = view->setViewpointAsync(newViewpoint, animationDuration);
+    startGeoViewNavigationUpdate(view->setViewpointAsync(newViewpoint, animationDuration));
   }
 
   void OverviewMapController::applyInsetNavigationToLocalSceneView(LocalSceneViewToolkit* view)
@@ -336,7 +370,7 @@ namespace Esri::ArcGISRuntime::Toolkit
     const Viewpoint newViewpoint{geometry_cast<Point>(viewpoint.targetGeometry()), viewpoint.targetScale() / scaleFactor()};
 
     constexpr float animationDuration{0};
-    m_setViewpointFuture = view->setViewpointAsync(newViewpoint, animationDuration);
+    startGeoViewNavigationUpdate(view->setViewpointAsync(newViewpoint, animationDuration));
   }
 
   void OverviewMapController::applyMapNavigationToInset(MapViewToolkit* view)
@@ -346,7 +380,7 @@ namespace Esri::ArcGISRuntime::Toolkit
     const Viewpoint newViewpoint{geometry_cast<Point>(viewpoint.targetGeometry()), viewpoint.targetScale() * scaleFactor(), viewpoint.rotation()};
 
     constexpr float animationDuration{0};
-    m_setViewpointInsetFuture = m_insetView->setViewpointAsync(newViewpoint, animationDuration);
+    startInsetNavigationUpdate(m_insetView->setViewpointAsync(newViewpoint, animationDuration));
   }
 
   void OverviewMapController::applySceneNavigationToInset(SceneViewToolkit* view)
@@ -356,7 +390,7 @@ namespace Esri::ArcGISRuntime::Toolkit
     const Viewpoint newViewpoint{geometry_cast<Point>(viewpoint.targetGeometry()), viewpoint.targetScale() * scaleFactor()};
 
     constexpr float animationDuration{0};
-    m_setViewpointInsetFuture = m_insetView->setViewpointAsync(newViewpoint, animationDuration);
+    startInsetNavigationUpdate(m_insetView->setViewpointAsync(newViewpoint, animationDuration));
   }
 
   void OverviewMapController::applyLocalSceneNavigationToInset(LocalSceneViewToolkit* view)
@@ -366,7 +400,7 @@ namespace Esri::ArcGISRuntime::Toolkit
     const Viewpoint newViewpoint{geometry_cast<Point>(viewpoint.targetGeometry()), viewpoint.targetScale() * scaleFactor()};
 
     constexpr float animationDuration{0};
-    m_setViewpointInsetFuture = m_insetView->setViewpointAsync(newViewpoint, animationDuration);
+    startInsetNavigationUpdate(m_insetView->setViewpointAsync(newViewpoint, animationDuration));
   }
 
   void OverviewMapController::disableInteractions()

--- a/uitools/common/src/OverviewMapController.h
+++ b/uitools/common/src/OverviewMapController.h
@@ -18,6 +18,7 @@
 
 // Qt headers
 #include <QFuture>
+#include <QFutureWatcher>
 #include <QObject>
 
 // Other headers
@@ -25,6 +26,7 @@
 
 namespace Esri::ArcGISRuntime
 {
+  class GeoView;
   class Graphic;
   class Symbol;
 } // namespace Esri::ArcGISRuntime
@@ -70,17 +72,25 @@ namespace Esri::ArcGISRuntime::Toolkit
 
     void disableInteractions();
 
+    bool shouldApplyNavigationUpdate(GeoView* geoView) const;
+
+    void resetNavigationSynchronization();
+    void startGeoViewNavigationUpdate(const QFuture<bool>& future);
+    void startInsetNavigationUpdate(const QFuture<bool>& future);
+
     void setupInsetMapForMap(MapViewToolkit* mapView);
     void setupInsetMapForScene(SceneViewToolkit* sceneView);
     void setupInsetMapForLocalScene(LocalSceneViewToolkit* localSceneView);
 
   private:
-    QFuture<bool> m_setViewpointFuture;
-    QFuture<bool> m_setViewpointInsetFuture;
+    QFutureWatcher<bool> m_setViewpointWatcher;
+    QFutureWatcher<bool> m_setViewpointInsetWatcher;
     MapViewToolkit* m_insetView = nullptr;
     QObject* m_geoView = nullptr;
     Graphic* m_reticle = nullptr;
     double m_scaleFactor = 25.0;
+    bool m_isUpdatingGeoViewFromInset = false;
+    bool m_isUpdatingInsetFromGeoView = false;
   };
 
 } // namespace Esri::ArcGISRuntime::Toolkit

--- a/uitools/common/src/OverviewMapController.h
+++ b/uitools/common/src/OverviewMapController.h
@@ -26,7 +26,6 @@
 
 namespace Esri::ArcGISRuntime
 {
-  class GeoView;
   class Graphic;
   class Symbol;
 } // namespace Esri::ArcGISRuntime
@@ -71,8 +70,6 @@ namespace Esri::ArcGISRuntime::Toolkit
     void applyLocalSceneNavigationToInset(LocalSceneViewToolkit* view);
 
     void disableInteractions();
-
-    bool shouldApplyNavigationUpdate(GeoView* geoView) const;
 
     void resetNavigationSynchronization();
     void startGeoViewNavigationUpdate(const QFuture<bool>& future);


### PR DESCRIPTION
We were using QFuture::isRunning() as the factor to decide whether a `viewpointChanged` callback was from an interaction update, or from a controller-driven setViewpointAsync(...).

That caused a feedback loop. When one view was updated programmatically to follow the other, its own `viewpointChanged` signal could arrive after the future no longer reported as running. At that point the controller tried to sync back in the other direction.

These changes solidify that there's only one driver at a time:
 * If the main view is being interacted with by the user, the inset view only listens and reacts - it does not try to sync the main view with it.
 * And the same in reverse if the user is interacting with the inset view.

