### PR TITLE
PopupMediaElement - add Alternative Text

### DIFF
--- a/uitools/common/src/PopupMediaItem.cpp
+++ b/uitools/common/src/PopupMediaItem.cpp
@@ -37,6 +37,11 @@ namespace Esri::ArcGISRuntime::Toolkit
 
   PopupMediaItem::~PopupMediaItem() = default;
 
+  QString PopupMediaItem::alternativeText() const
+  {
+    return m_popupMedia->alternativeText();
+  }
+
   QString PopupMediaItem::title() const
   {
     return m_popupMedia->title();

--- a/uitools/common/src/PopupMediaItem.h
+++ b/uitools/common/src/PopupMediaItem.h
@@ -35,6 +35,7 @@ namespace Esri::ArcGISRuntime
     class PopupMediaItem : public QObject
     {
       Q_OBJECT
+      Q_PROPERTY(QString alternativeText READ alternativeText NOTIFY popupMediaItemChanged)
       Q_PROPERTY(QString title READ title NOTIFY popupMediaItemChanged)
       Q_PROPERTY(QString caption READ caption NOTIFY popupMediaItemChanged)
       Q_PROPERTY(PopupMediaType popupMediaType READ popupMediaType NOTIFY popupMediaItemChanged)
@@ -46,6 +47,7 @@ namespace Esri::ArcGISRuntime
       ~PopupMediaItem() override;
 
     private:
+      QString alternativeText() const;
       QString title() const;
       QString caption() const;
       PopupMediaType popupMediaType() const;

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/MediaPopupElementView.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/MediaPopupElementView.qml
@@ -292,7 +292,7 @@ ColumnLayout {
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.verticalCenterOffset: model.alternativeText !== "" ? -20 : 0
 
-                            Text {
+                            Label {
                                 text: qsTr("Image unavailable")
                                 color: palette.text
                                 width: parent.width
@@ -301,7 +301,7 @@ ColumnLayout {
                                 verticalAlignment: Text.AlignVCenter
                             }
 
-                            Text {
+                            Label {
                                 text: model.alternativeText
                                 visible: model.alternativeText !== ""
                                 color: palette.text

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/MediaPopupElementView.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/MediaPopupElementView.qml
@@ -41,6 +41,29 @@ ColumnLayout {
 
     property var controller: null
 
+    function accessibleMediaName(media) {
+        if (!media)
+            return "";
+        if (media.alternativeText !== "")
+            return media.alternativeText;
+        if (media.title !== "")
+            return media.title;
+        if (media.caption !== "")
+            return media.caption;
+        return qsTr("Popup media");
+    }
+
+    function accessibleMediaDescription(media) {
+        if (!media)
+            return "";
+        const name = accessibleMediaName(media);
+        if (media.caption !== "" && media.caption !== name)
+            return media.caption;
+        if (media.title !== "" && media.title !== name)
+            return media.title;
+        return "";
+    }
+
     Dialog {
         id: fullScreenImageDialog
         modal: true
@@ -170,34 +193,40 @@ ColumnLayout {
             height: 170
             width: 220
 
+            function openPopupMedia() {
+                if (model.popupMediaType === QmlEnums.PopupMediaTypeImage) {
+                    // emit signal to bubble up image source url and link url to PopupViewController
+                    model.listModelData.imageClicked(model.listModelData.sourceUrl, model.listModelData.linkUrl);
+                }
+                if (model.popupMediaType !== QmlEnums.PopupMediaTypeImage ||
+                        (model.popupMediaType === QmlEnums.PopupMediaTypeImage && popupView.openImagesInApp)) {
+                    // fullScreenImageDialog.visible = true needs to happen before transfering the source component
+                    // to the full screen takeover Dialog in order to
+                    // use this as a trigger to change the label visibility
+                    // for PieSeries
+                    fullScreenImageDialog.visible = true;
+                    dialogContentLoader.sourceComponent = null;
+                    dialogContentLoader.sourceComponent = mediaLoader.sourceComponent;
+
+                    fullScreenImageDialog.modelData = model.listModelData;
+                    fullScreenImageDialog.imageTitle = model.title;
+                    fullScreenImageDialog.imageCaption = model.caption;
+                    fullScreenImageDialog.mediaType = model.popupMediaType;
+                }
+            }
+
             Loader {
                 id: mediaLoader
             }
 
             MouseArea {
                 anchors.fill: parent
+                Accessible.role: Accessible.Button
+                Accessible.name: mediaPopupElementView.accessibleMediaName(model)
+                Accessible.description: mediaPopupElementView.accessibleMediaDescription(model)
+                Accessible.onPressAction: delegatePopupMedia.openPopupMedia()
 
-                onClicked: {
-                    if (model.popupMediaType === QmlEnums.PopupMediaTypeImage) {
-                        // emit signal to bubble up image source url and link url to PopupViewController
-                        model.listModelData.imageClicked(model.listModelData.sourceUrl, model.listModelData.linkUrl);
-                    }
-                    if (model.popupMediaType !== QmlEnums.PopupMediaTypeImage ||
-                            (model.popupMediaType === QmlEnums.PopupMediaTypeImage && popupView.openImagesInApp)) {
-                        // fullScreenImageDialog.visible = true needs to happen before transfering the source component
-                        // to the full screen takeover Dialog in order to
-                        // use this as a trigger to change the label visibility
-                        // for PieSeries
-                        fullScreenImageDialog.visible = true;
-                        dialogContentLoader.sourceComponent = null;
-                        dialogContentLoader.sourceComponent = mediaLoader.sourceComponent;
-
-                        fullScreenImageDialog.modelData = model.listModelData;
-                        fullScreenImageDialog.imageTitle = model.title;
-                        fullScreenImageDialog.imageCaption = model.caption;
-                        fullScreenImageDialog.mediaType = model.popupMediaType;
-                    }
-                }
+                onClicked: delegatePopupMedia.openPopupMedia()
 
                 HoverHandler {
                     cursorShape: Qt.PointingHandCursor
@@ -256,13 +285,34 @@ ColumnLayout {
                         border.color: palette.dark
                         border.width: 1
 
-                        Text {
-                            text: qsTr("Image unavailable")
-                            color: palette.text
-                            anchors.centerIn: parent
-                            anchors.verticalCenterOffset: -15
-                            horizontalAlignment: Text.AlignHCenter
-                            verticalAlignment: Text.AlignVCenter
+                        Column {
+                            width: parent.width - (mediaPopupElementView.mediaMargin * 2)
+                            spacing: mediaPopupElementView.imageTextMargin
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.verticalCenterOffset: model.alternativeText !== "" ? -20 : 0
+
+                            Text {
+                                text: qsTr("Image unavailable")
+                                color: palette.text
+                                width: parent.width
+                                font.bold: true
+                                horizontalAlignment: Text.AlignHCenter
+                                verticalAlignment: Text.AlignVCenter
+                            }
+
+                            Text {
+                                text: model.alternativeText
+                                visible: model.alternativeText !== ""
+                                color: palette.text
+                                width: parent.width
+                                font.italic: true
+                                wrapMode: Text.WordWrap
+                                horizontalAlignment: Text.AlignHCenter
+                                verticalAlignment: Text.AlignVCenter
+                                elide: Text.ElideRight
+                                maximumLineCount: 2
+                            }
                         }
                     }
 
@@ -633,6 +683,16 @@ ColumnLayout {
                     bottom: parent.bottom
                     left: parent.left
                     right: parent.right
+                }
+
+                Rectangle {
+                    height: 1
+                    color: palette.dark
+                    anchors {
+                        top: parent.top
+                        left: parent.left
+                        right: parent.right
+                    }
                 }
 
                 ColumnLayout {

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/MediaPopupElementView.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/MediaPopupElementView.qml
@@ -678,21 +678,13 @@ ColumnLayout {
                 height: overlayTextLayout.height
                 color: "white"
                 opacity: 0.7
+                border.color: palette.dark
+                border.width: 1
 
                 anchors {
                     bottom: parent.bottom
                     left: parent.left
                     right: parent.right
-                }
-
-                Rectangle {
-                    height: 1
-                    color: palette.dark
-                    anchors {
-                        top: parent.top
-                        left: parent.left
-                        right: parent.right
-                    }
                 }
 
                 ColumnLayout {


### PR DESCRIPTION
This PR adds alternative text to the `MediaPopupElementView`. 
- adds alternative text to Accessible properties.
- displays alternative text when image fails to load.
- Added 1px border to the caption overlay since it was blending with the bg in light mode.(Minor fix)