### PR TITLE
Use processCertificate_ to mimic what actually happens.

### DIFF
--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/AuthenticatorClientCertificateView.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/AuthenticatorClientCertificateView.qml
@@ -182,11 +182,11 @@ Dialog {
 
         passwordDialog.openedChanged.connect(inputPasswordFn);
 
-        fileDialog.selectedFile = path;
-
-        // this will open the password dialog, which we are listening for it to become
-        // opened above to input the password
-        fileDialog.accept();
+        // Mirror the file dialog's accepted flow directly
+        currentCertificate = path;
+        passwordDialog.firstAttemptWithNoPassword = true;
+        passwordTextField.text = "";
+        processCertificate_();
     }
 
     function clickCancel() {


### PR DESCRIPTION
The dialog workflow stopped working for unknown reasons. We should just allow the logic to work normally rather than trying to call `fileDialog.accept();`