### PR TITLE
Refactor basemap gallery controller fetch logic and SR check; and address clang tidy warnings

### DIFF
--- a/uitools/common/src/BasemapGalleryController.cpp
+++ b/uitools/common/src/BasemapGalleryController.cpp
@@ -1,4 +1,4 @@
-/*******************************************************************************
+﻿/*******************************************************************************
  *  Copyright 2012-2021 Esri
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,6 +40,10 @@
 #include <QFuture>
 #include <QPersistentModelIndex>
 #include <QPointer>
+#include <QPromise>
+
+// C++ headers
+#include <memory>
 
 namespace Esri::ArcGISRuntime::Toolkit
 {
@@ -84,46 +88,22 @@ namespace Esri::ArcGISRuntime::Toolkit
       items2D.reserve(items.size());
 
       for (auto* item : items)
-      {
-        if (!item)
         {
-          continue;
-        }
+          if (!item)
+          {
+            continue;
+          }
 
-        if (item->is3D())
-        {
-          items3D.push_back(item);
-        }
-        else
-        {
-          items2D.push_back(item);
-        }
-      }
-    }
-
-    void appendGalleryItem(BasemapGalleryController* self, GenericListModel* gallery, BasemapGalleryItem* sourceItem)
-    {
-      if (!self || !gallery || !sourceItem || !sourceItem->basemap())
-      {
-        return;
-      }
-
-      if (sourceItem->is3D() && sourceItem->thumbnailOverride().isNull() && sourceItem->tooltipOverride().isEmpty())
-      {
-        self->append(sourceItem->basemap(), true);
-        return;
-      }
-
-      self->append(sourceItem->basemap(), sourceItem->thumbnailOverride(), sourceItem->tooltipOverride());
-      if (sourceItem->is3D())
-      {
-        const auto insertedIndex = gallery->index(gallery->rowCount() - 1);
-        if (auto* insertedItem = gallery->element<BasemapGalleryItem>(insertedIndex))
-        {
-          insertedItem->setIs3D(true);
+          if (item->is3D())
+          {
+            items3D.push_back(item);
+          }
+          else
+          {
+            items2D.push_back(item);
+          }
         }
       }
-    }
 
     /*!
       \internal
@@ -288,6 +268,11 @@ namespace Esri::ArcGISRuntime::Toolkit
       }
     }
 
+    /*!
+      \internal
+      Refreshes basemaps shown in the gallery from the loaded portal. Removes any gallery items that are no longer in the portal basemap lists
+      and preserves gallery items that are still in the portal basemap lists to preserve thumbnails and tooltips set by the developer.
+    */
     void refreshGalleryBasemaps(BasemapGalleryController* self, bool useDeveloperBasemaps = false)
     {
       if (!self)
@@ -324,13 +309,13 @@ namespace Esri::ArcGISRuntime::Toolkit
           {
             BasemapGalleryItem* existingItem = nullptr;
             for (auto* currentItem : currentItems)
-            {
-              if (currentItem && currentItem->basemap() == portalBasemap)
               {
-                existingItem = currentItem;
-                break;
+              if (currentItem && currentItem->basemap() == portalBasemap)
+                {
+                  existingItem = currentItem;
+                  break;
+                }
               }
-            }
 
             if (existingItem)
             {
@@ -400,7 +385,7 @@ namespace Esri::ArcGISRuntime::Toolkit
       gallery->removeRows(0, gallery->rowCount());
       for (auto* item : desiredItems)
       {
-        appendGalleryItem(self, gallery, item);
+        gallery->append(item);
       }
 
       emit self->basemapsChanged();
@@ -408,19 +393,36 @@ namespace Esri::ArcGISRuntime::Toolkit
 
     /*!
       \internal
-      Fetches basemaps from the portal if not already fetched, and then sets the gallery basemap items based on the portal basemap lists.
+      Fetches 2D and 3D basemaps from the current portal. Returns a boolean future that indicates when the fetch is complete and successful. 
      */
-    void fetchAndSetPortalBasemaps(BasemapGalleryController* self, Portal* portal, bool useDeveloperBasemaps)
+    QFuture<bool> fetchPortalBasemaps(BasemapGalleryController* self, Portal* portal, bool useDeveloperBasemaps)
     {
-      auto doOnPortalLoaded = [self, portal, useDeveloperBasemaps]()
+      auto promise = std::make_shared<QPromise<bool>>();
+      promise->start();
+      auto readyFuture = promise->future();
+
+      auto complete = [promise](bool ok)
+      {
+        promise->addResult(ok);
+        promise->finish();
+      };
+
+      if (!self || !portal)
+      {
+        complete(false);
+        return readyFuture;
+      }
+
+
+      auto fetchBasemapsFromLoadedPortal = [portal, useDeveloperBasemaps, complete]()
       {
         QList<QFuture<void>> basemapFutures;
         if (useDeveloperBasemaps)
         {
-          if (portal->developerBasemaps()->rowCount() == 0)
-          {
-            basemapFutures.append(portal->fetchDeveloperBasemapsAsync());
-          }
+        if (portal->developerBasemaps()->rowCount() == 0)
+        {
+          basemapFutures.append(portal->fetchDeveloperBasemapsAsync());
+        }
         }
         else if (portal->basemaps()->rowCount() == 0)
         {
@@ -434,46 +436,47 @@ namespace Esri::ArcGISRuntime::Toolkit
 
         if (basemapFutures.isEmpty())
         {
-          refreshGalleryBasemaps(self, useDeveloperBasemaps);
+          complete(true);
+        }
+        else if (basemapFutures.size() == 1)
+        {
+          basemapFutures.first().then([complete](const auto&)
+          {
+            complete(true);
+          });
         }
         else
         {
-          if (basemapFutures.size() == 1)
+          using FuturesVariant = std::variant<QFuture<void>, QFuture<void>>;
+          QtFuture::whenAll(basemapFutures.first(), basemapFutures.last())
+            .then([complete](const QList<FuturesVariant>&)
           {
-            basemapFutures.first().then(self, [self, useDeveloperBasemaps](const auto&)
-            {
-              refreshGalleryBasemaps(self, useDeveloperBasemaps);
-            });
-          }
-          else
-          {
-            using FuturesVariant = std::variant<QFuture<void>, QFuture<void>>;
-            QtFuture::whenAll(basemapFutures.first(), basemapFutures.last())
-              .then(self, [self, useDeveloperBasemaps](const QList<FuturesVariant>&)
-            {
-              refreshGalleryBasemaps(self, useDeveloperBasemaps);
-            });
-          }
+            complete(true);
+          });
         }
       };
 
       if (portal->loadStatus() == LoadStatus::Loaded)
       {
-        doOnPortalLoaded();
+        fetchBasemapsFromLoadedPortal();
       }
       else
       {
-        QObject::connect(portal, &Portal::doneLoading, self, [doOnPortalLoaded](const Error& loadError)
+        singleShotConnection(portal, &Portal::doneLoading, self, [fetchBasemapsFromLoadedPortal, complete](const Error& loadError)
         {
           if (!loadError.isEmpty())
           {
             qWarning() << "Failed to load portal with error:" << loadError.message() << loadError.additionalMessage();
+            complete(false);
             return;
           }
-          doOnPortalLoaded();
+          fetchBasemapsFromLoadedPortal();
         });
+
         portal->load();
-       }
+      }
+
+      return readyFuture;
     }
   } // namespace
 
@@ -531,7 +534,14 @@ namespace Esri::ArcGISRuntime::Toolkit
         return Qt::ItemFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
       }
     });
-    fetchAndSetPortalBasemaps(this, m_portal, /*useDeveloperBasemaps=*/true);
+    fetchPortalBasemaps(this, m_portal, /*useDeveloperBasemaps=*/true)
+      .then(this, [this](bool ready)
+    {
+      if (ready)
+      {
+        refreshGalleryBasemaps(this, true);
+      }
+    });
     // Have to set the property names, so the controller will know how to match the properties from
     // BasemapGalleryItem with the specific Qt::<namespace> invoked in the .data() from the View (ListView) obj
     m_gallery->setDisplayPropertyName("name");
@@ -610,7 +620,14 @@ namespace Esri::ArcGISRuntime::Toolkit
 
     if (m_portal)
     {
-      fetchAndSetPortalBasemaps(this, m_portal, false);
+      fetchPortalBasemaps(this, m_portal, false)
+        .then(this, [this](bool ready)
+      {
+        if (ready)
+        {
+          refreshGalleryBasemaps(this, false);
+        }
+      });
     }
 
     emit portalChanged();
@@ -664,22 +681,16 @@ namespace Esri::ArcGISRuntime::Toolkit
     }
   }
 
-  bool BasemapGalleryController::append(Basemap* basemap)
-  {
-    std::lock_guard<std::mutex> lock(m_galleryAccessMutex);
-    return m_gallery->append(new BasemapGalleryItem(basemap, this));
-  }
-
-  bool BasemapGalleryController::append(Basemap* basemap, bool is3D)
+  bool BasemapGalleryController::append(Basemap* basemap, bool is3D /* = false */)
   {
     std::lock_guard<std::mutex> lock(m_galleryAccessMutex);
     return m_gallery->append(new BasemapGalleryItem(basemap, {}, {}, is3D, this));
   }
 
-  bool BasemapGalleryController::append(Basemap* basemap, QImage thumbnail, QString tooltip)
+  bool BasemapGalleryController::append(Basemap* basemap, QImage thumbnail, QString tooltip /* = {} */, bool is3D /* = false */)
   {
     std::lock_guard<std::mutex> lock(m_galleryAccessMutex);
-    return m_gallery->append(new BasemapGalleryItem(basemap, std::move(thumbnail), std::move(tooltip), this));
+    return m_gallery->append(new BasemapGalleryItem(basemap, std::move(thumbnail), std::move(tooltip), is3D, this));
   }
 
   int BasemapGalleryController::basemapIndex(Basemap* basemap) const

--- a/uitools/common/src/BasemapGalleryController.cpp
+++ b/uitools/common/src/BasemapGalleryController.cpp
@@ -35,6 +35,8 @@
 #include <Scene.h>
 #include <SceneViewTypes.h>
 #include <SpatialReference.h>
+#include <GroupLayer.h>
+#include <Envelope.h>
 
 // Qt headers
 #include <QFuture>
@@ -47,65 +49,62 @@
 
 namespace Esri::ArcGISRuntime::Toolkit
 {
-
-  namespace
-  {
-    /*!
+  /*!
       \internal
      */
-    template<typename T>
-    auto* qPointerFrom(T* t)
-    {
-      return QPointer<T>{t};
-    }
+  template<typename T>
+  static auto* qPointerFrom(T* t)
+  {
+    return QPointer<T>{t};
+  }
 
-    QList<BasemapGalleryItem*> galleryItems(GenericListModel* gallery)
+  static QList<BasemapGalleryItem*> galleryItems(GenericListModel* gallery)
+  {
+    QList<BasemapGalleryItem*> items;
+    if (!gallery)
     {
-      QList<BasemapGalleryItem*> items;
-      if (!gallery)
-      {
-        return items;
-      }
-
-      items.reserve(gallery->rowCount());
-      for (int i = 0; i < gallery->rowCount(); ++i)
-      {
-        if (auto* item = gallery->element<BasemapGalleryItem>(gallery->index(i)))
-        {
-          items.push_back(item);
-        }
-      }
       return items;
     }
 
-    void splitGalleryItemsByDimension(const QList<BasemapGalleryItem*>& items,
-                                      QList<BasemapGalleryItem*>& items3D,
-                                      QList<BasemapGalleryItem*>& items2D)
+    items.reserve(gallery->rowCount());
+    for (int i = 0; i < gallery->rowCount(); ++i)
     {
-      items3D.clear();
-      items2D.clear();
-      items3D.reserve(items.size());
-      items2D.reserve(items.size());
+      if (auto* item = gallery->element<BasemapGalleryItem>(gallery->index(i)))
+      {
+        items.push_back(item);
+      }
+    }
+    return items;
+  }
 
-      for (auto* item : items)
-        {
-          if (!item)
-          {
-            continue;
-          }
+  static void splitGalleryItemsByDimension(const QList<BasemapGalleryItem*>& items,
+                                           QList<BasemapGalleryItem*>& items3D,
+                                           QList<BasemapGalleryItem*>& items2D)
+  {
+    items3D.clear();
+    items2D.clear();
+    items3D.reserve(items.size());
+    items2D.reserve(items.size());
 
-          if (item->is3D())
-          {
-            items3D.push_back(item);
-          }
-          else
-          {
-            items2D.push_back(item);
-          }
-        }
+    for (auto* item : items)
+    {
+      if (!item)
+      {
+        continue;
       }
 
-    /*!
+      if (item->is3D())
+      {
+        items3D.push_back(item);
+      }
+      else
+      {
+        items2D.push_back(item);
+      }
+    }
+  }
+
+  /*!
       \internal
       Takes a map or scene, and connects to it and its basemap.
       Emits a basemapChanged signal when:
@@ -115,41 +114,41 @@ namespace Esri::ArcGISRuntime::Toolkit
       We automatically disconnect from the map/scene's old basemap if the
       map/scene basemapChanged signal is fired.
      */
-    template<typename T>
-    void connectToBasemap(BasemapGalleryController* self, T* geoModel)
+  template<typename T>
+  static void connectToBasemap(BasemapGalleryController* self, T* geoModel)
+  {
+    static_assert(std::is_base_of_v<GeoModel, T>, "Must be a GeoModel.");
+
+    if (!geoModel)
     {
-      static_assert(std::is_base_of<GeoModel, T>::value, "Must be a GeoModel.");
-
-      if (!geoModel)
-      {
-        return;
-      }
-
-      const auto listenToLoadSignals = [self](Basemap* basemap)
-      {
-        if (basemap)
-        {
-          if (basemap->loadStatus() != LoadStatus::Loaded)
-          {
-            QObject::connect(basemap, &Basemap::doneLoading, self, &BasemapGalleryController::currentBasemapChanged);
-          }
-        }
-      };
-
-      // If basemap changes on map or scene, disconnect from basemap and
-      // signal that basemap has changed.
-      QObject::connect(geoModel, &T::basemapChanged, self, [self, listenToLoadSignals, geoModel](Basemap* oldBasemap)
-      {
-        QObject::disconnect(self, nullptr, oldBasemap, nullptr);
-        auto* newBasemap = geoModel->basemap();
-        listenToLoadSignals(newBasemap); // Connect to new basemap.
-        self->setCurrentBasemap(newBasemap);
-      });
-
-      listenToLoadSignals(geoModel->basemap());
+      return;
     }
 
-    /*!
+    const auto listenToLoadSignals = [self](Basemap* basemap)
+    {
+      if (basemap)
+      {
+        if (basemap->loadStatus() != LoadStatus::Loaded)
+        {
+          QObject::connect(basemap, &Basemap::doneLoading, self, &BasemapGalleryController::currentBasemapChanged);
+        }
+      }
+    };
+
+    // If basemap changes on map or scene, disconnect from basemap and
+    // signal that basemap has changed.
+    QObject::connect(geoModel, &T::basemapChanged, self, [self, listenToLoadSignals, geoModel](Basemap* oldBasemap)
+    {
+      QObject::disconnect(self, nullptr, oldBasemap, nullptr);
+      auto* newBasemap = geoModel->basemap();
+      listenToLoadSignals(newBasemap); // Connect to new basemap.
+      self->setCurrentBasemap(newBasemap);
+    });
+
+    listenToLoadSignals(geoModel->basemap());
+  }
+
+  /*!
       \internal
       Connect to [Scene/Map].
 
@@ -157,40 +156,31 @@ namespace Esri::ArcGISRuntime::Toolkit
       2. Discover the runtime type of GeoModel
       3. Connect to that type's basemapChanged signal.
      */
-    void connectToGeoModel(BasemapGalleryController* self, GeoModel* geoModel)
+  static void connectToGeoModel(BasemapGalleryController* self, GeoModel* geoModel)
+  {
+    doOnLoaded(geoModel, self, [self, geoModel]
     {
-      doOnLoaded(geoModel, self, [self, geoModel]
-      {
-        self->setCurrentBasemap(geoModel->basemap());
-      });
+      self->setCurrentBasemap(geoModel->basemap());
+    });
 
-      // TODO: Cleanup this when GeoModel itself exposes the
-      // basemapChanged signal.
-      if (auto* scene = qobject_cast<Scene*>(geoModel))
-      {
-        connectToBasemap(self, scene);
-      }
-      else if (auto* map = qobject_cast<Map*>(geoModel))
-      {
-        connectToBasemap(self, map);
-      }
-    }
+    connectToBasemap(self, geoModel);
+  }
 
-    /*!
+  /*!
       \internal
       1. Disconnect from the associated Map/Scene.
       2. Disconnect from the associated Basemap.
      */
-    void disconnectFromGeoModel(BasemapGalleryController* self, GeoModel* geoModel)
+  static void disconnectFromGeoModel(BasemapGalleryController* self, GeoModel* geoModel)
+  {
+    QObject::disconnect(geoModel, nullptr, self, nullptr);
+    if (Basemap* basemap = geoModel->basemap())
     {
-      QObject::disconnect(geoModel, nullptr, self, nullptr);
-      if (Basemap* basemap = geoModel->basemap())
-      {
-        QObject::disconnect(basemap, nullptr, self, nullptr);
-      }
+      QObject::disconnect(basemap, nullptr, self, nullptr);
     }
+  }
 
-    /*!
+  /*!
       \internal
       Triggered when a basemap is added to the gallery.
 
@@ -199,44 +189,47 @@ namespace Esri::ArcGISRuntime::Toolkit
       3. We emit BasemapGalleryController::currentBasemapChanged if the current basemap was
       added to the gallery.
      */
-    void onBasemapAddedToGallery(BasemapGalleryController* self, GenericListModel* gallery, const QModelIndex& index, BasemapGalleryItem* galleryItem)
+  static void onBasemapAddedToGallery(BasemapGalleryController* self,
+                                      GenericListModel* gallery,
+                                      const QModelIndex& index,
+                                      BasemapGalleryItem* galleryItem)
+  {
+    if (!galleryItem)
     {
-      if (!galleryItem)
-      {
-        return;
-      }
-
-      const auto pIndex = QPersistentModelIndex(index);
-      const auto notifyChange = [pIndex, gallery]
-      {
-        // Notify that the item has changed.
-        if (pIndex.isValid())
-        {
-          emit gallery->dataChanged(pIndex, pIndex);
-        }
-      };
-
-      QObject::connect(galleryItem, &BasemapGalleryItem::basemapChanged, self, notifyChange);
-      QObject::connect(galleryItem, &BasemapGalleryItem::thumbnailChanged, self, notifyChange);
-      QObject::connect(galleryItem, &BasemapGalleryItem::tooltipChanged, self, notifyChange);
-
-      auto* basemap = galleryItem->basemap();
-
-      if (basemap && basemap->loadStatus() != LoadStatus::Loaded)
-      {
-        basemap->load();
-      }
-
-      if (self->currentBasemap() == basemap)
-      {
-        // If the currently active basemap was added to the gallery, we notify
-        // downstream consumers that the currently active basemap has changed also to
-        // trigger UI updates
-        emit self->currentBasemapChanged();
-      }
+      return;
     }
 
-    /*!
+    const auto pIndex = QPersistentModelIndex(index);
+    const auto notifyChange = [pIndex, gallery]
+    {
+      // Notify that the item has changed.
+      if (pIndex.isValid())
+      {
+        emit gallery->dataChanged(pIndex, pIndex);
+      }
+    };
+
+    QObject::connect(galleryItem, &BasemapGalleryItem::basemapChanged, self, notifyChange);
+    QObject::connect(galleryItem, &BasemapGalleryItem::thumbnailChanged, self, notifyChange);
+    QObject::connect(galleryItem, &BasemapGalleryItem::tooltipChanged, self, notifyChange);
+
+    auto* basemap = galleryItem->basemap();
+
+    if (basemap && basemap->loadStatus() != LoadStatus::Loaded)
+    {
+      basemap->load();
+    }
+
+    if (self->currentBasemap() == basemap)
+    {
+      // If the currently active basemap was added to the gallery, we notify
+      // downstream consumers that the currently active basemap has changed also to
+      // trigger UI updates
+      emit self->currentBasemapChanged();
+    }
+  }
+
+  /*!
       \internal
       Triggered when a basemap is removed from the gallery.
 
@@ -245,240 +238,225 @@ namespace Esri::ArcGISRuntime::Toolkit
       removed from the gallery.
       3. We delete the GalleryItem if we are the parent.
      */
-    void onBasemapRemovedFromGallery(BasemapGalleryController* self, BasemapGalleryItem* galleryItem)
+  static void onBasemapRemovedFromGallery(BasemapGalleryController* self, BasemapGalleryItem* galleryItem)
+  {
+    if (!galleryItem)
     {
-      if (!galleryItem)
-      {
-        return;
-      }
-
-      QObject::disconnect(galleryItem, nullptr, self, nullptr);
-
-      if (self->currentBasemap() == galleryItem->basemap())
-      {
-        // If the currently active basemap was added to the gallery, we let
-        // downstream consumers the currently active basemap has changed also to
-        // trigger UI updates.
-        emit self->currentBasemapChanged();
-      }
-
-      if (galleryItem->parent() == self)
-      {
-        galleryItem->deleteLater();
-      }
+      return;
     }
 
-    /*!
+    QObject::disconnect(galleryItem, nullptr, self, nullptr);
+
+    if (self->currentBasemap() == galleryItem->basemap())
+    {
+      // If the currently active basemap was added to the gallery, we let
+      // downstream consumers the currently active basemap has changed also to
+      // trigger UI updates.
+      emit self->currentBasemapChanged();
+    }
+
+    if (galleryItem->parent() == self)
+    {
+      galleryItem->deleteLater();
+    }
+  }
+
+  /*!
       \internal
       Refreshes basemaps shown in the gallery from the loaded portal. Removes any gallery items that are no longer in the portal basemap lists
       and preserves gallery items that are still in the portal basemap lists to preserve thumbnails and tooltips set by the developer.
     */
-    void refreshGalleryBasemaps(BasemapGalleryController* self, bool useDeveloperBasemaps = false)
+  static void refreshGalleryBasemaps(BasemapGalleryController* self)
+  {
+    if (!self)
     {
-      if (!self)
-      {
-        return;
-      }
+      return;
+    }
 
-      auto* gallery = self->gallery();
-      auto* portal = self->portal();
-      if (!gallery || !portal || portal->loadStatus() != LoadStatus::Loaded)
-      {
-        return;
-      }
-      const auto currentItems = galleryItems(gallery);
-      QList<BasemapGalleryItem*> current3DItems;
-      QList<BasemapGalleryItem*> current2DItems;
-      splitGalleryItemsByDimension(currentItems, current3DItems, current2DItems);
+    auto* gallery = self->gallery();
+    auto* portal = self->portal();
+    if (!gallery || !portal || portal->loadStatus() != LoadStatus::Loaded)
+    {
+      return;
+    }
+    const auto currentItems = galleryItems(gallery);
+    QList<BasemapGalleryItem*> current3DItems;
+    QList<BasemapGalleryItem*> current2DItems;
+    splitGalleryItemsByDimension(currentItems, current3DItems, current2DItems);
 
-      // Remove gallery items that are no longer in the portal basemap lists, and keep gallery items that are
-      // still in the portal basemap lists to preserve thumbnails and tooltips set by the developer.
-      auto preserveAndSortGalleryItems = [self](const QList<BasemapGalleryItem*>& currentItems, BasemapListModel* portalBasemaps,
-                                                bool is3D = false) -> QList<BasemapGalleryItem*>
+    // Keep gallery items that are still in the portal basemap lists to preserve thumbnails and tooltips set by the developer.
+    auto preserveAndSortGalleryItems = [self](const QList<BasemapGalleryItem*>& currentItems, BasemapListModel* portalBasemaps,
+                                              bool is3D = false) -> QList<BasemapGalleryItem*>
+    {
+      if (!portalBasemaps)
       {
-        if (!portalBasemaps)
+        return {};
+      }
+      QList<BasemapGalleryItem*> preservedItems = currentItems;
+      for (auto* portalBasemap : *portalBasemaps)
+      {
+        bool found = false;
+        for (auto* currentItem : currentItems)
         {
-          return {};
-        }
-        QList<BasemapGalleryItem*> preservedItems;
-        preservedItems.reserve(currentItems.size());
-
-        for (int i = 0; i < portalBasemaps->size(); ++i)
-        {
-          auto* portalBasemap = portalBasemaps->at(i);
+          if (currentItem && currentItem->basemap() == portalBasemap)
           {
-            BasemapGalleryItem* existingItem = nullptr;
-            for (auto* currentItem : currentItems)
-              {
-              if (currentItem && currentItem->basemap() == portalBasemap)
-                {
-                  existingItem = currentItem;
-                  break;
-                }
-              }
-
-            if (existingItem)
-            {
-              preservedItems.push_back(existingItem);
-            }
-            else
-            {
-              preservedItems.push_back(new BasemapGalleryItem(portalBasemap, {}, {}, is3D, self));
-            }
-          }
-        }
-
-        // Now sort the items
-        std::sort(preservedItems.begin(), preservedItems.end(), [](BasemapGalleryItem* left, BasemapGalleryItem* right)
-        {
-          if (!left || !left->basemap() || !left->basemap()->item() || left->basemap()->item()->title().isEmpty())
-          {
-            return false;
-          }
-          if (!right || !right->basemap() || !right->basemap()->item() || right->basemap()->item()->title().isEmpty())
-          {
-            return true;
-          }
-          return left->basemap()->item()->title() < right->basemap()->item()->title();
-        });
-
-        return preservedItems;
-      };
-
-      QList<BasemapGalleryItem*> desiredItems;
-
-      if (qobject_cast<Scene*>(self->geoModel()))
-      {
-        desiredItems = preserveAndSortGalleryItems(current3DItems, portal->basemaps3D(), true);
-      }
-
-      if (useDeveloperBasemaps)
-      {
-        desiredItems.append(preserveAndSortGalleryItems(current2DItems, portal->developerBasemaps()));
-      }
-      else
-      {
-        desiredItems.append(preserveAndSortGalleryItems(current2DItems, portal->basemaps()));
-      }
-
-      // If the current items in the gallery are in the same order and have the same classification (2D vs 3D) as the desired items,
-      // then we can skip refreshing the gallery to avoid unnecessary UI updates that can cause flickering.
-      auto changed = currentItems.size() != desiredItems.size();
-      if (!changed)
-      {
-        for (int i = 0; i < currentItems.size(); ++i)
-        {
-          if (!currentItems.at(i) || !desiredItems.at(i) || currentItems.at(i)->basemap() != desiredItems.at(i)->basemap() ||
-              currentItems.at(i)->is3D() != desiredItems.at(i)->is3D())
-          {
-            changed = true;
+            found = true;
             break;
           }
         }
+        if (!found)
+        {
+          preservedItems.push_back(new BasemapGalleryItem(portalBasemap, {}, {}, is3D, self));
+        }
       }
 
-      if (!changed)
+      // Now sort the items
+      std::sort(preservedItems.begin(), preservedItems.end(), [](BasemapGalleryItem* left, BasemapGalleryItem* right)
       {
-        return;
-      }
+        if (!left || !left->basemap() || !left->basemap()->item() || left->basemap()->item()->title().isEmpty())
+        {
+          return false;
+        }
+        if (!right || !right->basemap() || !right->basemap()->item() || right->basemap()->item()->title().isEmpty())
+        {
+          return true;
+        }
+        return left->basemap()->item()->title() < right->basemap()->item()->title();
+      });
 
-      gallery->removeRows(0, gallery->rowCount());
-      for (auto* item : desiredItems)
-      {
-        gallery->append(item);
-      }
+      return preservedItems;
+    };
 
-      emit self->basemapsChanged();
+    QList<BasemapGalleryItem*> desiredItems;
+
+    if (qobject_cast<Scene*>(self->geoModel()))
+    {
+      desiredItems = preserveAndSortGalleryItems(current3DItems, portal->basemaps3D(), true);
     }
 
-    /*!
+    if (self->portal()->portalUser()) // returns nullptr if portal access is anonymous
+    {
+      desiredItems.append(preserveAndSortGalleryItems(current2DItems, portal->basemaps()));
+    }
+    else
+    {
+      desiredItems.append(preserveAndSortGalleryItems(current2DItems, portal->developerBasemaps()));
+    }
+
+    // If the current items in the gallery are in the same order and have the same classification (2D vs 3D) as the desired items,
+    // then we can skip refreshing the gallery to avoid unnecessary UI updates that can cause flickering.
+
+    // Quickly check if the size changed
+    auto changed = currentItems.size() != desiredItems.size();
+
+    // If the size did not change, then check if the items are in the same order and have the same classification (2D vs 3D)
+    if (!changed)
+    {
+      for (int i = 0; i < currentItems.size(); ++i)
+      {
+        if (!currentItems.at(i) || !desiredItems.at(i) || currentItems.at(i)->basemap() != desiredItems.at(i)->basemap() ||
+            currentItems.at(i)->is3D() != desiredItems.at(i)->is3D())
+        {
+          changed = true;
+          break;
+        }
+      }
+    }
+
+    if (!changed)
+    {
+      return;
+    }
+
+    gallery->removeRows(0, gallery->rowCount());
+
+    for (auto* item : std::as_const(desiredItems))
+    {
+      gallery->append(item);
+    }
+    emit self->basemapsChanged();
+  }
+
+  /*!
       \internal
       Fetches 2D and 3D basemaps from the current portal. Returns a boolean future that indicates when the fetch is complete and successful. 
      */
-    QFuture<bool> fetchPortalBasemaps(BasemapGalleryController* self, Portal* portal, bool useDeveloperBasemaps)
+  static QFuture<bool> fetchPortalBasemaps(BasemapGalleryController* self, Portal* portal)
+  {
+    auto promise = std::make_shared<QPromise<bool>>();
+    promise->start();
+    auto readyFuture = promise->future();
+
+    auto complete = [promise](bool ok)
     {
-      auto promise = std::make_shared<QPromise<bool>>();
-      promise->start();
-      auto readyFuture = promise->future();
+      promise->addResult(ok);
+      promise->finish();
+    };
 
-      auto complete = [promise](bool ok)
+    if (!self || !portal)
+    {
+      complete(false);
+      return readyFuture;
+    }
+
+    auto* geoModel = self->geoModel();
+
+    auto fetchBasemapsFromLoadedPortal = [portal, geoModel, complete]()
+    {
+      QList<QFuture<void>> basemapFutures;
+      if (!portal->portalUser()) // returns nullptr if portal access is anonymous
       {
-        promise->addResult(ok);
-        promise->finish();
-      };
-
-      if (!self || !portal)
-      {
-        complete(false);
-        return readyFuture;
-      }
-
-
-      auto fetchBasemapsFromLoadedPortal = [portal, useDeveloperBasemaps, complete]()
-      {
-        QList<QFuture<void>> basemapFutures;
-        if (useDeveloperBasemaps)
-        {
         if (portal->developerBasemaps()->rowCount() == 0)
         {
           basemapFutures.append(portal->fetchDeveloperBasemapsAsync());
         }
-        }
-        else if (portal->basemaps()->rowCount() == 0)
+      }
+      else
+      {
+        if (portal->basemaps()->rowCount() == 0)
         {
           basemapFutures.append(portal->fetchBasemapsAsync());
         }
+      }
 
+      // Check if geoModel is a scene
+      if (qobject_cast<Scene*>(geoModel))
+      {
         if (portal->basemaps3D()->rowCount() == 0)
         {
           basemapFutures.append(portal->fetch3DBasemapsAsync());
         }
-
-        if (basemapFutures.isEmpty())
-        {
-          complete(true);
-        }
-        else if (basemapFutures.size() == 1)
-        {
-          basemapFutures.first().then([complete](const auto&)
-          {
-            complete(true);
-          });
-        }
-        else
-        {
-          using FuturesVariant = std::variant<QFuture<void>, QFuture<void>>;
-          QtFuture::whenAll(basemapFutures.first(), basemapFutures.last())
-            .then([complete](const QList<FuturesVariant>&)
-          {
-            complete(true);
-          });
-        }
-      };
-
-      if (portal->loadStatus() == LoadStatus::Loaded)
-      {
-        fetchBasemapsFromLoadedPortal();
-      }
-      else
-      {
-        singleShotConnection(portal, &Portal::doneLoading, self, [fetchBasemapsFromLoadedPortal, complete](const Error& loadError)
-        {
-          if (!loadError.isEmpty())
-          {
-            qWarning() << "Failed to load portal with error:" << loadError.message() << loadError.additionalMessage();
-            complete(false);
-            return;
-          }
-          fetchBasemapsFromLoadedPortal();
-        });
-
-        portal->load();
       }
 
-      return readyFuture;
+      QtFuture::whenAll(basemapFutures.begin(), basemapFutures.end())
+        .then([complete](const QList<QFuture<void>>&)
+      {
+        complete(true);
+      });
+    };
+
+    if (portal->loadStatus() == LoadStatus::Loaded)
+    {
+      fetchBasemapsFromLoadedPortal();
     }
-  } // namespace
+    else
+    {
+      singleShotConnection(portal, &Portal::doneLoading, self, [fetchBasemapsFromLoadedPortal, complete](const Error& loadError)
+      {
+        if (!loadError.isEmpty())
+        {
+          qWarning() << "Failed to load portal with error:" << loadError.message() << loadError.additionalMessage();
+          complete(false);
+          return;
+        }
+        fetchBasemapsFromLoadedPortal();
+      });
+
+      portal->load();
+    }
+
+    return readyFuture;
+  }
 
   BasemapGalleryController::BasemapGalleryController(QObject* parent) :
     QObject(parent),
@@ -490,6 +468,7 @@ namespace Esri::ArcGISRuntime::Toolkit
     {
       if (parent.isValid())
       {
+        // We only care about top-level items in the gallery; ignore children of other items
         return;
       }
 
@@ -508,9 +487,9 @@ namespace Esri::ArcGISRuntime::Toolkit
     {
       if (parent.isValid())
       {
+        // This gallery should only ever have top level items, so ignore any children of other items
         return;
       }
-
       for (auto i = first; i <= last; ++i)
       {
         auto index = m_gallery->index(i);
@@ -520,28 +499,29 @@ namespace Esri::ArcGISRuntime::Toolkit
         }
       }
     });
+
     m_gallery->setFlagsCallback([this](const QModelIndex& index)
     {
-      BasemapGalleryItem* galleryItem = m_gallery->element<BasemapGalleryItem>(index);
+      auto* galleryItem = m_gallery->element<BasemapGalleryItem>(index);
       if (!basemapMatchesCurrentSpatialReference(galleryItem->basemap()))
       {
         //disabled item flags
         return Qt::ItemFlags(Qt::NoItemFlags);
       }
-      else
-      {
-        //enabled and selectable item flags
-        return Qt::ItemFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
-      }
+
+      //enabled and selectable item flags
+      return Qt::ItemFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
     });
-    fetchPortalBasemaps(this, m_portal, /*useDeveloperBasemaps=*/true)
+
+    fetchPortalBasemaps(this, m_portal)
       .then(this, [this](bool ready)
     {
       if (ready)
       {
-        refreshGalleryBasemaps(this, true);
+        refreshGalleryBasemaps(this);
       }
     });
+
     // Have to set the property names, so the controller will know how to match the properties from
     // BasemapGalleryItem with the specific Qt::<namespace> invoked in the .data() from the View (ListView) obj
     m_gallery->setDisplayPropertyName("name");
@@ -581,7 +561,19 @@ namespace Esri::ArcGISRuntime::Toolkit
 
     emit geoModelChanged();
 
-    refreshGalleryBasemaps(this);
+    // Refresh the gallery basemaps, potentially adding or removing 3D basemaps
+    if (m_portal)
+    {
+      fetchPortalBasemaps(this, m_portal)
+        .then(this, [this](bool ready)
+      {
+        if (ready)
+        {
+          refreshGalleryBasemaps(this);
+        }
+      });
+    }
+
     //forcing all the items in the gallery to recalculate the ::ItemFlags for the view.
     emit m_gallery->dataChanged(m_gallery->index(0), m_gallery->index(std::max(m_gallery->rowCount() - 1, 0)));
   }
@@ -607,6 +599,7 @@ namespace Esri::ArcGISRuntime::Toolkit
     {
       disconnect(m_portal, nullptr, this, nullptr);
       m_gallery->removeRows(0, m_gallery->rowCount());
+
       if (m_portal->parent() == this)
       {
         // If we own the Portal we can delete it when
@@ -620,12 +613,12 @@ namespace Esri::ArcGISRuntime::Toolkit
 
     if (m_portal)
     {
-      fetchPortalBasemaps(this, m_portal, false)
+      fetchPortalBasemaps(this, m_portal)
         .then(this, [this](bool ready)
       {
         if (ready)
         {
-          refreshGalleryBasemaps(this, false);
+          refreshGalleryBasemaps(this);
         }
       });
     }
@@ -648,6 +641,7 @@ namespace Esri::ArcGISRuntime::Toolkit
         {
           return;
         }
+
         if (!basemapMatchesCurrentSpatialReference(basemap))
         {
           // force redraw for the single basemapGalleryItem updated
@@ -683,13 +677,13 @@ namespace Esri::ArcGISRuntime::Toolkit
 
   bool BasemapGalleryController::append(Basemap* basemap, bool is3D /* = false */)
   {
-    std::lock_guard<std::mutex> lock(m_galleryAccessMutex);
+    std::scoped_lock<std::mutex> lock(m_galleryAccessMutex);
     return m_gallery->append(new BasemapGalleryItem(basemap, {}, {}, is3D, this));
   }
 
   bool BasemapGalleryController::append(Basemap* basemap, QImage thumbnail, QString tooltip /* = {} */, bool is3D /* = false */)
   {
-    std::lock_guard<std::mutex> lock(m_galleryAccessMutex);
+    std::scoped_lock<std::mutex> lock(m_galleryAccessMutex);
     return m_gallery->append(new BasemapGalleryItem(basemap, std::move(thumbnail), std::move(tooltip), is3D, this));
   }
 
@@ -711,54 +705,80 @@ namespace Esri::ArcGISRuntime::Toolkit
   {
     if (!basemap || !basemap->baseLayers() || basemap->baseLayers()->isEmpty())
     {
+      // If the basemap object doesn't exist or doesn't have layers, flag it as incompatible
       return false;
     }
 
-    const SpatialReference basemapSR = basemap->baseLayers()->first()->spatialReference();
+    const SpatialReference basemapSR = [this](LayerListModel* baseLayers) -> SpatialReference
+    {
+      // Note: Ogc3dTilesLayer is a 3D layer type and can be reprojected. The following tile layer types *cannot* be reprojected
+      static const QList<LayerType> tileLayerTypes = {LayerType::ImageTiledLayer,     LayerType::ServiceImageTiledLayer,
+                                                      LayerType::ArcGISMapImageLayer, LayerType::ArcGISTiledLayer,
+                                                      LayerType::RasterLayer,         LayerType::ArcGISVectorTiledLayer,
+                                                      LayerType::WebTiledLayer};
+
+      for (auto* layer : *baseLayers)
+      {
+        if (tileLayerTypes.contains(layer->layerType()))
+        {
+          return layer->spatialReference();
+        }
+
+        // Check for group layer contents
+        if (layer->layerType() == LayerType::GroupLayer)
+        {
+          if (auto* groupLayer = dynamic_cast<GroupLayer*>(layer))
+          {
+            for (auto* subLayer : *groupLayer->layers())
+            {
+              if (tileLayerTypes.contains(subLayer->layerType()))
+              {
+                return subLayer->spatialReference();
+              }
+            }
+          }
+        }
+      }
+      return {};
+    }(basemap->baseLayers());
 
     if (basemapSR.isEmpty())
     {
-      return true; // case used by the listview painter
-    }
-
-    if (!m_geoModel)
-    {
+      // The basemap may not have tiled layers that cannot be reprojected, or may not be loaded
       return true;
     }
 
-    // For Global scenes using the Geographic tiling scheme, allow any geographic basemap SR.
+    // Check GeoModel
+    if (!m_geoModel)
+    {
+      // If the user has not set a GeoModel, do not flag any basemaps as incompatible
+      return true;
+    }
+
+    // Check Scene GeoModels
     if (auto* scene = qobject_cast<Scene*>(m_geoModel))
     {
-      bool containsTileLayer = false;
-      for (auto* layer : *basemap->baseLayers())
-      {
-        if (layer->layerType() == LayerType::ArcGISVectorTiledLayer || layer->layerType() == LayerType::ImageTiledLayer)
-        {
-          containsTileLayer = true;
-          break;
-        }
-      }
-      if (!containsTileLayer)
-      {
-        // If the basemap does not contain any tile layers, we allow it to be applied to any scene.
-        return true;
-      }
+      // Global Scenes use Geographic and WebMercator SceneViewTilingSchemes while Local scenes use Automatic.
+      // Therefore this check only affects Global Scenes
       if (scene->sceneViewTilingScheme() == SceneViewTilingScheme::Geographic)
       {
         return basemapSR.isGeographic();
       }
-      else if (scene->sceneViewTilingScheme() == SceneViewTilingScheme::WebMercator)
+      if (scene->sceneViewTilingScheme() == SceneViewTilingScheme::WebMercator)
       {
         return basemapSR == SpatialReference::webMercator();
       }
+      // else SceneViewTilingScheme::Automatic -- continue with Local Scene case
     }
 
-    // If no spatial reference is set, any basemap can be applied.
+    // Map and Local Scene cases
     if (m_geoModel->spatialReference().isEmpty())
     {
+      // If no spatial reference is set, the GeoModel will use the SR of the basemap
       return true;
     }
 
+    // Finally, check if the basemap spatial reference matches the GeoModel spatial reference
     return basemapSR == m_geoModel->spatialReference();
   }
 

--- a/uitools/common/src/BasemapGalleryController.cpp
+++ b/uitools/common/src/BasemapGalleryController.cpp
@@ -74,33 +74,6 @@ namespace Esri::ArcGISRuntime::Toolkit
     return items;
   }
 
-  static void splitGalleryItemsByDimension(const QList<BasemapGalleryItem*>& items,
-                                           QList<BasemapGalleryItem*>& items3D,
-                                           QList<BasemapGalleryItem*>& items2D)
-  {
-    items3D.clear();
-    items2D.clear();
-    items3D.reserve(items.size());
-    items2D.reserve(items.size());
-
-    for (auto* item : items)
-    {
-      if (!item)
-      {
-        continue;
-      }
-
-      if (item->is3D())
-      {
-        items3D.push_back(item);
-      }
-      else
-      {
-        items2D.push_back(item);
-      }
-    }
-  }
-
   /*!
     \internal
     Takes a map or scene, and connects to it and its basemap.
@@ -136,7 +109,7 @@ namespace Esri::ArcGISRuntime::Toolkit
     // signal that basemap has changed.
     QObject::connect(geoModel, &T::basemapChanged, self, [self, listenToLoadSignals, geoModel](Basemap* oldBasemap)
     {
-      QObject::disconnect(self, nullptr, oldBasemap, nullptr);
+      QObject::disconnect(oldBasemap, nullptr, self, nullptr);
       auto* newBasemap = geoModel->basemap();
       listenToLoadSignals(newBasemap); // Connect to new basemap.
       self->setCurrentBasemap(newBasemap);
@@ -276,7 +249,6 @@ namespace Esri::ArcGISRuntime::Toolkit
     {
       return;
     }
-    const auto currentItems = galleryItems(gallery);
 
     // Remove existing gallery items to refresh the gallery with new basemaps from the portal. This will also disconnect signals from the removed gallery items.
     gallery->removeRows(0, gallery->rowCount());

--- a/uitools/common/src/BasemapGalleryController.cpp
+++ b/uitools/common/src/BasemapGalleryController.cpp
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  *  Copyright 2012-2021 Esri
  *
@@ -54,6 +53,76 @@ namespace Esri::ArcGISRuntime::Toolkit
     auto* qPointerFrom(T* t)
     {
       return QPointer<T>{t};
+    }
+
+    QList<BasemapGalleryItem*> galleryItems(GenericListModel* gallery)
+    {
+      QList<BasemapGalleryItem*> items;
+      if (!gallery)
+      {
+        return items;
+      }
+
+      items.reserve(gallery->rowCount());
+      for (int i = 0; i < gallery->rowCount(); ++i)
+      {
+        if (auto* item = gallery->element<BasemapGalleryItem>(gallery->index(i)))
+        {
+          items.push_back(item);
+        }
+      }
+      return items;
+    }
+
+    void splitGalleryItemsByDimension(const QList<BasemapGalleryItem*>& items,
+                                      QList<BasemapGalleryItem*>& items3D,
+                                      QList<BasemapGalleryItem*>& items2D)
+    {
+      items3D.clear();
+      items2D.clear();
+      items3D.reserve(items.size());
+      items2D.reserve(items.size());
+
+      for (auto* item : items)
+      {
+        if (!item)
+        {
+          continue;
+        }
+
+        if (item->is3D())
+        {
+          items3D.push_back(item);
+        }
+        else
+        {
+          items2D.push_back(item);
+        }
+      }
+    }
+
+    void appendGalleryItem(BasemapGalleryController* self, GenericListModel* gallery, BasemapGalleryItem* sourceItem)
+    {
+      if (!self || !gallery || !sourceItem || !sourceItem->basemap())
+      {
+        return;
+      }
+
+      if (sourceItem->is3D() && sourceItem->thumbnailOverride().isNull() && sourceItem->tooltipOverride().isEmpty())
+      {
+        self->append(sourceItem->basemap(), true);
+        return;
+      }
+
+      self->append(sourceItem->basemap(), sourceItem->thumbnailOverride(), sourceItem->tooltipOverride());
+      if (sourceItem->is3D())
+      {
+        const auto insertedIndex = gallery->index(gallery->rowCount() - 1);
+        if (auto* insertedItem = gallery->element<BasemapGalleryItem>(insertedIndex))
+        {
+          insertedItem->setIs3D(true);
+        }
+      }
     }
 
     /*!
@@ -219,92 +288,194 @@ namespace Esri::ArcGISRuntime::Toolkit
       }
     }
 
+    void refreshGalleryBasemaps(BasemapGalleryController* self, bool useDeveloperBasemaps = false)
+    {
+      if (!self)
+      {
+        return;
+      }
+
+      auto* gallery = self->gallery();
+      auto* portal = self->portal();
+      if (!gallery || !portal || portal->loadStatus() != LoadStatus::Loaded)
+      {
+        return;
+      }
+      const auto currentItems = galleryItems(gallery);
+      QList<BasemapGalleryItem*> current3DItems;
+      QList<BasemapGalleryItem*> current2DItems;
+      splitGalleryItemsByDimension(currentItems, current3DItems, current2DItems);
+
+      // Remove gallery items that are no longer in the portal basemap lists, and keep gallery items that are
+      // still in the portal basemap lists to preserve thumbnails and tooltips set by the developer.
+      auto preserveAndSortGalleryItems = [self](const QList<BasemapGalleryItem*>& currentItems, BasemapListModel* portalBasemaps,
+                                                bool is3D = false) -> QList<BasemapGalleryItem*>
+      {
+        if (!portalBasemaps)
+        {
+          return {};
+        }
+        QList<BasemapGalleryItem*> preservedItems;
+        preservedItems.reserve(currentItems.size());
+
+        for (int i = 0; i < portalBasemaps->size(); ++i)
+        {
+          auto* portalBasemap = portalBasemaps->at(i);
+          {
+            BasemapGalleryItem* existingItem = nullptr;
+            for (auto* currentItem : currentItems)
+            {
+              if (currentItem && currentItem->basemap() == portalBasemap)
+              {
+                existingItem = currentItem;
+                break;
+              }
+            }
+
+            if (existingItem)
+            {
+              preservedItems.push_back(existingItem);
+            }
+            else
+            {
+              preservedItems.push_back(new BasemapGalleryItem(portalBasemap, {}, {}, is3D, self));
+            }
+          }
+        }
+
+        // Now sort the items
+        std::sort(preservedItems.begin(), preservedItems.end(), [](BasemapGalleryItem* left, BasemapGalleryItem* right)
+        {
+          if (!left || !left->basemap() || !left->basemap()->item() || left->basemap()->item()->title().isEmpty())
+          {
+            return false;
+          }
+          if (!right || !right->basemap() || !right->basemap()->item() || right->basemap()->item()->title().isEmpty())
+          {
+            return true;
+          }
+          return left->basemap()->item()->title() < right->basemap()->item()->title();
+        });
+
+        return preservedItems;
+      };
+
+      QList<BasemapGalleryItem*> desiredItems;
+
+      if (qobject_cast<Scene*>(self->geoModel()))
+      {
+        desiredItems = preserveAndSortGalleryItems(current3DItems, portal->basemaps3D(), true);
+      }
+
+      if (useDeveloperBasemaps)
+      {
+        desiredItems.append(preserveAndSortGalleryItems(current2DItems, portal->developerBasemaps()));
+      }
+      else
+      {
+        desiredItems.append(preserveAndSortGalleryItems(current2DItems, portal->basemaps()));
+      }
+
+      // If the current items in the gallery are in the same order and have the same classification (2D vs 3D) as the desired items,
+      // then we can skip refreshing the gallery to avoid unnecessary UI updates that can cause flickering.
+      auto changed = currentItems.size() != desiredItems.size();
+      if (!changed)
+      {
+        for (int i = 0; i < currentItems.size(); ++i)
+        {
+          if (!currentItems.at(i) || !desiredItems.at(i) || currentItems.at(i)->basemap() != desiredItems.at(i)->basemap() ||
+              currentItems.at(i)->is3D() != desiredItems.at(i)->is3D())
+          {
+            changed = true;
+            break;
+          }
+        }
+      }
+
+      if (!changed)
+      {
+        return;
+      }
+
+      gallery->removeRows(0, gallery->rowCount());
+      for (auto* item : desiredItems)
+      {
+        appendGalleryItem(self, gallery, item);
+      }
+
+      emit self->basemapsChanged();
+    }
+
     /*!
       \internal
-      Takes a BasemapListModel*, sorts them alphabetically, and adds them to the basemap gallery.
-
-      Because the basemaps are initially unloaded, Basemap->item() must be used to access the
-      basemap metadata. The basemaps are sorted using Basemap->item()->title().
+      Fetches basemaps from the portal if not already fetched, and then sets the gallery basemap items based on the portal basemap lists.
      */
-    void sortBasemapsAndAddToGallery(BasemapGalleryController* self, BasemapListModel* basemaps, bool is3D = false)
+    void fetchAndSetPortalBasemaps(BasemapGalleryController* self, Portal* portal, bool useDeveloperBasemaps)
     {
-      // Convert BasemapListModel into a Basemap* vector and sort basemaps alphabetically using the title
-      std::vector<Basemap*> basemapsVector;
-      basemapsVector.reserve(basemaps->rowCount());
-      std::copy(std::cbegin(*basemaps), std::cend(*basemaps), std::back_inserter(basemapsVector));
-      std::sort(std::begin(basemapsVector), std::end(basemapsVector), [](Basemap* b1, Basemap* b2)
+      auto doOnPortalLoaded = [self, portal, useDeveloperBasemaps]()
       {
-        // Check validity of basemap->item() and if title() is empty. If either is true, push to end of list.
-        if (!b1->item() || b1->item()->title().isEmpty())
+        QList<QFuture<void>> basemapFutures;
+        if (useDeveloperBasemaps)
         {
-          return false;
+          if (portal->developerBasemaps()->rowCount() == 0)
+          {
+            basemapFutures.append(portal->fetchDeveloperBasemapsAsync());
+          }
         }
-        else if (!b2->item() || b2->item()->title().isEmpty())
+        else if (portal->basemaps()->rowCount() == 0)
         {
-          return true;
+          basemapFutures.append(portal->fetchBasemapsAsync());
+        }
+
+        if (portal->basemaps3D()->rowCount() == 0)
+        {
+          basemapFutures.append(portal->fetch3DBasemapsAsync());
+        }
+
+        if (basemapFutures.isEmpty())
+        {
+          refreshGalleryBasemaps(self, useDeveloperBasemaps);
         }
         else
         {
-          return b1->item()->title() < b2->item()->title();
-        }
-      });
-
-      for (auto* basemap : basemapsVector)
-      {
-        self->append(basemap, is3D);
-      }
-    }
-
-    /*!
-      \internal
-      Calls Portal::fetchDeveloperBasemapsAsync on the portal. Note that we do
-      not call Portal::fetchBasemapsAsync. The former call is for retrieving the modern API-key
-      metered basemaps, while the latter returns older-style basemaps. The latter is required
-      only when the user applies a custom portal, as it is also the call for retrieving an
-      enterprises's custom basemaps if set.
-     */
-    void setToDefaultBasemaps(BasemapGalleryController* self, Portal* portal)
-    {
-      // Load the portal and kick-off the group discovery.
-      QObject::connect(portal, &Portal::doneLoading, self, [portal, self](const Error& e)
-      {
-        if (!e.isEmpty())
-        {
-          return;
-        }
-
-        portal->fetchDeveloperBasemapsAsync().then(self, [portal, self]()
-        {
-          // Sort and append the basemaps to the gallery.
-          BasemapListModel* basemaps = portal->developerBasemaps();
-          sortBasemapsAndAddToGallery(self, basemaps);
-          // Notify the demo that the basemaps have changed.
-          emit self->basemapsChanged();
-        });
-
-        if (qobject_cast<Scene*>(self->geoModel()))
-        {
-          portal->fetch3DBasemapsAsync().then(self, [portal, self]()
+          if (basemapFutures.size() == 1)
           {
-            // Sort and append the basemaps to the gallery.
-            BasemapListModel* basemaps = portal->basemaps3D();
-            sortBasemapsAndAddToGallery(self, basemaps, true);
-            // Notify the demo that the basemaps have changed.
-            emit self->basemapsChanged();
-          });
+            basemapFutures.first().then(self, [self, useDeveloperBasemaps](const auto&)
+            {
+              refreshGalleryBasemaps(self, useDeveloperBasemaps);
+            });
+          }
+          else
+          {
+            using FuturesVariant = std::variant<QFuture<void>, QFuture<void>>;
+            QtFuture::whenAll(basemapFutures.first(), basemapFutures.last())
+              .then(self, [self, useDeveloperBasemaps](const QList<FuturesVariant>&)
+            {
+              refreshGalleryBasemaps(self, useDeveloperBasemaps);
+            });
+          }
         }
-      });
-      portal->load();
+      };
+
+      if (portal->loadStatus() == LoadStatus::Loaded)
+      {
+        doOnPortalLoaded();
+      }
+      else
+      {
+        QObject::connect(portal, &Portal::doneLoading, self, [doOnPortalLoaded](const Error& loadError)
+        {
+          if (!loadError.isEmpty())
+          {
+            qWarning() << "Failed to load portal with error:" << loadError.message() << loadError.additionalMessage();
+            return;
+          }
+          doOnPortalLoaded();
+        });
+        portal->load();
+       }
     }
   } // namespace
-
-  /*!
-    \inmodule Esri.ArcGISRuntime.Toolkit
-    \class Esri::ArcGISRuntime::Toolkit::BasemapGalleryController
-    \internal
-
-    This class is an internal implementation detail and is subject to change.
-   */
 
   BasemapGalleryController::BasemapGalleryController(QObject* parent) :
     QObject(parent),
@@ -360,9 +531,9 @@ namespace Esri::ArcGISRuntime::Toolkit
         return Qt::ItemFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
       }
     });
-    setToDefaultBasemaps(this, m_portal);
+    fetchAndSetPortalBasemaps(this, m_portal, /*useDeveloperBasemaps=*/true);
     // Have to set the property names, so the controller will know how to match the properties from
-    // basemapgalleryitem with the specific Qt::<namespace> invoked in the .data() from the View (ListView) obj
+    // BasemapGalleryItem with the specific Qt::<namespace> invoked in the .data() from the View (ListView) obj
     m_gallery->setDisplayPropertyName("name");
     m_gallery->setDecorationPropertyName("thumbnail");
     m_gallery->setTooltipPropertyName("tooltip");
@@ -399,6 +570,8 @@ namespace Esri::ArcGISRuntime::Toolkit
     }
 
     emit geoModelChanged();
+
+    refreshGalleryBasemaps(this);
     //forcing all the items in the gallery to recalculate the ::ItemFlags for the view.
     emit m_gallery->dataChanged(m_gallery->index(0), m_gallery->index(std::max(m_gallery->rowCount() - 1, 0)));
   }
@@ -437,48 +610,7 @@ namespace Esri::ArcGISRuntime::Toolkit
 
     if (m_portal)
     {
-      // If portal basemaps are populated, add the contents to the gallery.
-      // Otherwise attempt a fetch of the contents then add to the gallery.
-      doOnLoaded(m_portal, this, [this]
-      {
-        if (m_portal->basemaps()->rowCount() > 0)
-        {
-          for (auto* basemap : *m_portal->basemaps())
-          {
-            append(basemap);
-          }
-        }
-        else
-        {
-          m_portal->fetchBasemapsAsync()
-          .then(this, [this]()
-          {
-            BasemapListModel* basemaps = m_portal->basemaps();
-            sortBasemapsAndAddToGallery(this, basemaps);
-            emit basemapsChanged();
-          });
-        }
-
-        if (qobject_cast<Scene*>(m_geoModel))
-        {
-          if (m_portal->basemaps3D()->rowCount() > 0)
-          {
-            for (auto* basemap : *m_portal->basemaps3D())
-            {
-              append(basemap);
-            }
-          }
-          else
-          {
-            m_portal->fetch3DBasemapsAsync().then(this, [this]()
-            {
-              BasemapListModel* basemaps = m_portal->basemaps3D();
-              sortBasemapsAndAddToGallery(this, basemaps, true);
-              emit basemapsChanged();
-            });
-          }
-        }
-      });
+      fetchAndSetPortalBasemaps(this, m_portal, false);
     }
 
     emit portalChanged();
@@ -515,7 +647,7 @@ namespace Esri::ArcGISRuntime::Toolkit
       }
       else
       {
-        qDebug() << "problem in loading the layer";
+        qWarning() << "problem in loading the layer";
       }
     };
     if (basemap->baseLayers()->size() > 0)
@@ -586,33 +718,37 @@ namespace Esri::ArcGISRuntime::Toolkit
     // For Global scenes using the Geographic tiling scheme, allow any geographic basemap SR.
     if (auto* scene = qobject_cast<Scene*>(m_geoModel))
     {
+      bool containsTileLayer = false;
+      for (auto* layer : *basemap->baseLayers())
+      {
+        if (layer->layerType() == LayerType::ArcGISVectorTiledLayer || layer->layerType() == LayerType::ImageTiledLayer)
+        {
+          containsTileLayer = true;
+          break;
+        }
+      }
+      if (!containsTileLayer)
+      {
+        // If the basemap does not contain any tile layers, we allow it to be applied to any scene.
+        return true;
+      }
       if (scene->sceneViewTilingScheme() == SceneViewTilingScheme::Geographic)
       {
         return basemapSR.isGeographic();
       }
+      else if (scene->sceneViewTilingScheme() == SceneViewTilingScheme::WebMercator)
+      {
+        return basemapSR == SpatialReference::webMercator();
+      }
     }
 
-    const SpatialReference geoModelSR = [](GeoModel* geoModel)
-    {
-      if (auto* scene = qobject_cast<Scene*>(geoModel))
-      {
-        // Local Scenes use SceneViewTilingScheme::Automatic, so won't engage with this logic
-        // Global Scenes are always in WGS84, but can support WebMercator SRs if the tiling Scheme is set to SceneViewTilingScheme::WebMercator
-        if (scene->sceneViewTilingScheme() == SceneViewTilingScheme::WebMercator)
-        {
-          return SpatialReference::webMercator();
-        }
-      }
-      return geoModel->spatialReference();
-    }(m_geoModel);
-
     // If no spatial reference is set, any basemap can be applied.
-    if (geoModelSR.isEmpty())
+    if (m_geoModel->spatialReference().isEmpty())
     {
       return true;
     }
 
-    return basemapSR == geoModelSR;
+    return basemapSR == m_geoModel->spatialReference();
   }
 
   void BasemapGalleryController::setGeoModelFromGeoView(QObject* view)

--- a/uitools/common/src/BasemapGalleryController.cpp
+++ b/uitools/common/src/BasemapGalleryController.cpp
@@ -27,6 +27,7 @@
 #include <Basemap.h>
 #include <BasemapListModel.h>
 #include <Error.h>
+#include <GroupLayer.h>
 #include <Item.h>
 #include <Layer.h>
 #include <LayerListModel.h>
@@ -35,8 +36,6 @@
 #include <Scene.h>
 #include <SceneViewTypes.h>
 #include <SpatialReference.h>
-#include <GroupLayer.h>
-#include <Envelope.h>
 
 // Qt headers
 #include <QFuture>
@@ -45,18 +44,16 @@
 #include <QPromise>
 
 // C++ headers
+#include <algorithm>
 #include <memory>
+#include <type_traits>
+#include <utility>
 
 namespace Esri::ArcGISRuntime::Toolkit
 {
   /*!
-      \internal
-     */
-  template<typename T>
-  static auto* qPointerFrom(T* t)
-  {
-    return QPointer<T>{t};
-  }
+    \internal
+   */
 
   static QList<BasemapGalleryItem*> galleryItems(GenericListModel* gallery)
   {
@@ -105,15 +102,15 @@ namespace Esri::ArcGISRuntime::Toolkit
   }
 
   /*!
-      \internal
-      Takes a map or scene, and connects to it and its basemap.
-      Emits a basemapChanged signal when:
-      - The map/scene basemapChanged signal fires.
-      - The basemap load status has changed.
+    \internal
+    Takes a map or scene, and connects to it and its basemap.
+    Emits a basemapChanged signal when:
+    - The map/scene basemapChanged signal fires.
+    - The basemap load status has changed.
 
-      We automatically disconnect from the map/scene's old basemap if the
-      map/scene basemapChanged signal is fired.
-     */
+    We automatically disconnect from the map/scene's old basemap if the
+    map/scene basemapChanged signal is fired.
+   */
   template<typename T>
   static void connectToBasemap(BasemapGalleryController* self, T* geoModel)
   {
@@ -149,13 +146,13 @@ namespace Esri::ArcGISRuntime::Toolkit
   }
 
   /*!
-      \internal
-      Connect to [Scene/Map].
+    \internal
+    Connect to [Scene/Map].
 
-      1. Update our cached basemap with the Scene/Map basemap.
-      2. Discover the runtime type of GeoModel
-      3. Connect to that type's basemapChanged signal.
-     */
+    1. Update our cached basemap with the Scene/Map basemap.
+    2. Discover the runtime type of GeoModel
+    3. Connect to that type's basemapChanged signal.
+   */
   static void connectToGeoModel(BasemapGalleryController* self, GeoModel* geoModel)
   {
     doOnLoaded(geoModel, self, [self, geoModel]
@@ -167,10 +164,10 @@ namespace Esri::ArcGISRuntime::Toolkit
   }
 
   /*!
-      \internal
-      1. Disconnect from the associated Map/Scene.
-      2. Disconnect from the associated Basemap.
-     */
+    \internal
+    1. Disconnect from the associated Map/Scene.
+    2. Disconnect from the associated Basemap.
+   */
   static void disconnectFromGeoModel(BasemapGalleryController* self, GeoModel* geoModel)
   {
     QObject::disconnect(geoModel, nullptr, self, nullptr);
@@ -181,14 +178,14 @@ namespace Esri::ArcGISRuntime::Toolkit
   }
 
   /*!
-      \internal
-      Triggered when a basemap is added to the gallery.
+    \internal
+    Triggered when a basemap is added to the gallery.
 
-      1. We listen for GalleryItem changes.
-      2. We force the basemap to load if not already.
-      3. We emit BasemapGalleryController::currentBasemapChanged if the current basemap was
-      added to the gallery.
-     */
+    1. We listen for GalleryItem changes.
+    2. We force the basemap to load if not already.
+    3. We emit BasemapGalleryController::currentBasemapChanged if the current basemap was
+    added to the gallery.
+   */
   static void onBasemapAddedToGallery(BasemapGalleryController* self,
                                       GenericListModel* gallery,
                                       const QModelIndex& index,
@@ -230,14 +227,14 @@ namespace Esri::ArcGISRuntime::Toolkit
   }
 
   /*!
-      \internal
-      Triggered when a basemap is removed from the gallery.
+    \internal
+    Triggered when a basemap is removed from the gallery.
 
-      1. We disconnect from the GalleryItem.
-      2. We emit BasemapGalleryController::currentBasemapChanged if the current basemap was
-      removed from the gallery.
-      3. We delete the GalleryItem if we are the parent.
-     */
+    1. We disconnect from the GalleryItem.
+    2. We emit BasemapGalleryController::currentBasemapChanged if the current basemap was
+    removed from the gallery.
+    3. We delete the GalleryItem if we are the parent.
+   */
   static void onBasemapRemovedFromGallery(BasemapGalleryController* self, BasemapGalleryItem* galleryItem)
   {
     if (!galleryItem)
@@ -262,10 +259,10 @@ namespace Esri::ArcGISRuntime::Toolkit
   }
 
   /*!
-      \internal
-      Refreshes basemaps shown in the gallery from the loaded portal. Removes any gallery items that are no longer in the portal basemap lists
-      and preserves gallery items that are still in the portal basemap lists to preserve thumbnails and tooltips set by the developer.
-    */
+    \internal
+    Refreshes basemaps shown in the gallery from the loaded portal. Removes all existing BasemapGalleryItems and replaces them with
+    new instances from the Portal. Assumes the Portal is already loaded and the Basemaps have been fetched.
+  */
   static void refreshGalleryBasemaps(BasemapGalleryController* self)
   {
     if (!self)
@@ -280,107 +277,41 @@ namespace Esri::ArcGISRuntime::Toolkit
       return;
     }
     const auto currentItems = galleryItems(gallery);
-    QList<BasemapGalleryItem*> current3DItems;
-    QList<BasemapGalleryItem*> current2DItems;
-    splitGalleryItemsByDimension(currentItems, current3DItems, current2DItems);
 
-    // Keep gallery items that are still in the portal basemap lists to preserve thumbnails and tooltips set by the developer.
-    auto preserveAndSortGalleryItems = [self](const QList<BasemapGalleryItem*>& currentItems, BasemapListModel* portalBasemaps,
-                                              bool is3D = false) -> QList<BasemapGalleryItem*>
-    {
-      if (!portalBasemaps)
-      {
-        return {};
-      }
-      QList<BasemapGalleryItem*> preservedItems = currentItems;
-      for (auto* portalBasemap : *portalBasemaps)
-      {
-        bool found = false;
-        for (auto* currentItem : currentItems)
-        {
-          if (currentItem && currentItem->basemap() == portalBasemap)
-          {
-            found = true;
-            break;
-          }
-        }
-        if (!found)
-        {
-          preservedItems.push_back(new BasemapGalleryItem(portalBasemap, {}, {}, is3D, self));
-        }
-      }
-
-      // Now sort the items
-      std::sort(preservedItems.begin(), preservedItems.end(), [](BasemapGalleryItem* left, BasemapGalleryItem* right)
-      {
-        if (!left || !left->basemap() || !left->basemap()->item() || left->basemap()->item()->title().isEmpty())
-        {
-          return false;
-        }
-        if (!right || !right->basemap() || !right->basemap()->item() || right->basemap()->item()->title().isEmpty())
-        {
-          return true;
-        }
-        return left->basemap()->item()->title() < right->basemap()->item()->title();
-      });
-
-      return preservedItems;
-    };
-
-    QList<BasemapGalleryItem*> desiredItems;
-
-    if (qobject_cast<Scene*>(self->geoModel()))
-    {
-      desiredItems = preserveAndSortGalleryItems(current3DItems, portal->basemaps3D(), true);
-    }
-
-    if (self->portal()->portalUser()) // returns nullptr if portal access is anonymous
-    {
-      desiredItems.append(preserveAndSortGalleryItems(current2DItems, portal->basemaps()));
-    }
-    else
-    {
-      desiredItems.append(preserveAndSortGalleryItems(current2DItems, portal->developerBasemaps()));
-    }
-
-    // If the current items in the gallery are in the same order and have the same classification (2D vs 3D) as the desired items,
-    // then we can skip refreshing the gallery to avoid unnecessary UI updates that can cause flickering.
-
-    // Quickly check if the size changed
-    auto changed = currentItems.size() != desiredItems.size();
-
-    // If the size did not change, then check if the items are in the same order and have the same classification (2D vs 3D)
-    if (!changed)
-    {
-      for (int i = 0; i < currentItems.size(); ++i)
-      {
-        if (!currentItems.at(i) || !desiredItems.at(i) || currentItems.at(i)->basemap() != desiredItems.at(i)->basemap() ||
-            currentItems.at(i)->is3D() != desiredItems.at(i)->is3D())
-        {
-          changed = true;
-          break;
-        }
-      }
-    }
-
-    if (!changed)
-    {
-      return;
-    }
-
+    // Remove existing gallery items to refresh the gallery with new basemaps from the portal. This will also disconnect signals from the removed gallery items.
     gallery->removeRows(0, gallery->rowCount());
 
-    for (auto* item : std::as_const(desiredItems))
+    if (auto* scene = dynamic_cast<Scene*>(self->geoModel()))
     {
-      gallery->append(item);
+      // Add 3D basemaps
+      for (auto* basemap3D : *portal->basemaps3D())
+      {
+        self->append(basemap3D, true);
+      }
     }
+    if (portal->portalUser())
+    {
+      // Add Org Basemaps
+      for (auto* basemap : *portal->basemaps())
+      {
+        self->append(basemap, false);
+      }
+    }
+    else // Anonymous Portal
+    {
+      for (auto* basemap : *portal->developerBasemaps())
+      {
+        self->append(basemap, false);
+      }
+    }
+
     emit self->basemapsChanged();
   }
 
   /*!
-      \internal
-      Fetches 2D and 3D basemaps from the current portal. Returns a boolean future that indicates when the fetch is complete and successful. 
-     */
+    \internal
+    Fetches 2D and 3D basemaps from the current portal. Returns a boolean future that indicates when the fetch is complete and successful. 
+   */
   static QFuture<bool> fetchPortalBasemaps(BasemapGalleryController* self, Portal* portal)
   {
     auto promise = std::make_shared<QPromise<bool>>();
@@ -419,13 +350,9 @@ namespace Esri::ArcGISRuntime::Toolkit
         }
       }
 
-      // Check if geoModel is a scene
-      if (qobject_cast<Scene*>(geoModel))
+      if (portal->basemaps3D()->rowCount() == 0)
       {
-        if (portal->basemaps3D()->rowCount() == 0)
-        {
-          basemapFutures.append(portal->fetch3DBasemapsAsync());
-        }
+        basemapFutures.append(portal->fetch3DBasemapsAsync());
       }
 
       QtFuture::whenAll(basemapFutures.begin(), basemapFutures.end())
@@ -483,7 +410,7 @@ namespace Esri::ArcGISRuntime::Toolkit
     });
 
     // Listen in to items removed from the gallery.
-    connect(m_gallery, &GenericListModel::rowsRemoved, this, [this](const QModelIndex& parent, int first, int last)
+    connect(m_gallery, &GenericListModel::rowsAboutToBeRemoved, this, [this](const QModelIndex& parent, int first, int last)
     {
       if (parent.isValid())
       {
@@ -564,14 +491,7 @@ namespace Esri::ArcGISRuntime::Toolkit
     // Refresh the gallery basemaps, potentially adding or removing 3D basemaps
     if (m_portal)
     {
-      fetchPortalBasemaps(this, m_portal)
-        .then(this, [this](bool ready)
-      {
-        if (ready)
-        {
-          refreshGalleryBasemaps(this);
-        }
-      });
+      refreshGalleryBasemaps(this);
     }
 
     //forcing all the items in the gallery to recalculate the ::ItemFlags for the view.
@@ -675,13 +595,25 @@ namespace Esri::ArcGISRuntime::Toolkit
     }
   }
 
-  bool BasemapGalleryController::append(Basemap* basemap, bool is3D /* = false */)
+  bool BasemapGalleryController::append(Basemap* basemap)
+  {
+    std::scoped_lock<std::mutex> lock(m_galleryAccessMutex);
+    return m_gallery->append(new BasemapGalleryItem(basemap, {}, {}, false, this));
+  }
+
+  bool BasemapGalleryController::append(Basemap* basemap, bool is3D)
   {
     std::scoped_lock<std::mutex> lock(m_galleryAccessMutex);
     return m_gallery->append(new BasemapGalleryItem(basemap, {}, {}, is3D, this));
   }
 
-  bool BasemapGalleryController::append(Basemap* basemap, QImage thumbnail, QString tooltip /* = {} */, bool is3D /* = false */)
+  bool BasemapGalleryController::append(Basemap* basemap, QImage thumbnail, QString tooltip)
+  {
+    std::scoped_lock<std::mutex> lock(m_galleryAccessMutex);
+    return m_gallery->append(new BasemapGalleryItem(basemap, std::move(thumbnail), std::move(tooltip), false, this));
+  }
+
+  bool BasemapGalleryController::append(Basemap* basemap, QImage thumbnail, QString tooltip, bool is3D)
   {
     std::scoped_lock<std::mutex> lock(m_galleryAccessMutex);
     return m_gallery->append(new BasemapGalleryItem(basemap, std::move(thumbnail), std::move(tooltip), is3D, this));

--- a/uitools/common/src/BasemapGalleryController.h
+++ b/uitools/common/src/BasemapGalleryController.h
@@ -63,9 +63,10 @@ namespace Esri::ArcGISRuntime::Toolkit
 
     Q_INVOKABLE void setCurrentBasemap(Basemap* basemap);
 
-    Q_INVOKABLE bool append(Basemap* basemap, bool is3D = false);
-
-    Q_INVOKABLE bool append(Basemap* basemap, QImage thumbnail, QString tooltip = {}, bool is3D = false);
+    Q_INVOKABLE bool append(Basemap* basemap);
+    Q_INVOKABLE bool append(Basemap* basemap, bool is3D);
+    Q_INVOKABLE bool append(Basemap* basemap, QImage thumbnail, QString tooltip = {});
+    Q_INVOKABLE bool append(Basemap* basemap, QImage thumbnail, QString tooltip, bool is3D);
 
     Q_INVOKABLE int basemapIndex(Basemap* basemap) const;
 

--- a/uitools/common/src/BasemapGalleryController.h
+++ b/uitools/common/src/BasemapGalleryController.h
@@ -63,11 +63,9 @@ namespace Esri::ArcGISRuntime::Toolkit
 
     Q_INVOKABLE void setCurrentBasemap(Basemap* basemap);
 
-    Q_INVOKABLE bool append(Basemap* basemap);
+    Q_INVOKABLE bool append(Basemap* basemap, bool is3D = false);
 
-    Q_INVOKABLE bool append(Basemap* basemap, bool is3D);
-
-    Q_INVOKABLE bool append(Basemap* basemap, QImage thumbnail, QString tooltip = {});
+    Q_INVOKABLE bool append(Basemap* basemap, QImage thumbnail, QString tooltip = {}, bool is3D = false);
 
     Q_INVOKABLE int basemapIndex(Basemap* basemap) const;
 


### PR DESCRIPTION
This PR targets the BasemapGalleryController class with three main goals:

1. Refine the `BasemapGalleryController::basemapMatchesCurrentSpatialReference` method. 
  - Many layer types can be reprojected in a GeoModel with a different SR. This update only checks the SR of basemap base layers types that _cannot_ be reprojected.
2. Refine the fetchBasemap logic.
  - If `m_portal->portalUser()` doesn't exist, then we treat the user as anonymous and fetch developer basemaps. Previously, even if the user explicitly set the Portal with an anonymous portal -- arcgis.com -- we would still try to fetch organizational basemaps (and return nothing).
  - We now always fetch 3D basemaps from the portal, and we update what basemap items are shown to the user when the GeoModel changes. Previously we would only fetch 3D basemaps at construction if GeoModel was already set and a Scene (which never happened because the c'tor didn't take a GeoModel) and on Portal changed (which needed a Scene set at that time). If the GeoModel was initially a Map and then changed to a Scene, 3D basemaps would not be fetched or shown. Now we change what basemaps are shown to the user when the GeoModel changes too.
3. clang-tidy cleanup

- [llvm-prefer-static-over-anonymous-namespace]: function is declared in an anonymous namespace; prefer using 'static' for restricting visibility 
  - BasemapGalleryController.cpp:54:11: 'qPointerFrom'
  - BasemapGalleryController.cpp:70:10: 'connectToBasemap'
  - BasemapGalleryController.cpp:111:10:  'connectToGeoModel' 
  - BasemapGalleryController.cpp:135:10: 'disconnectFromGeoModel'
  - BasemapGalleryController.cpp:153:10: 'onBasemapAddedToGallery'
  - BasemapGalleryController.cpp:199:10: 'onBasemapRemovedFromGallery'
  - BasemapGalleryController.cpp:229:10: 'sortBasemapsAndAddToGallery'
  - BasemapGalleryController.cpp:266:10: 'setToDefaultBasemaps'
- [modernize-type-traits]: warning: use c++17 style variable templates 
  - BasemapGalleryController.cpp:72:21
- [llvm-else-after-return] warning: do not use 'else' after 'return' 
  - BasemapGalleryController.cpp:242:9 
  - BasemapGalleryController.cpp:357:7
- [hicpp-use-auto] warning: use auto when initializing with a template cast to avoid duplicating the type name 
  - BasemapGalleryController.cpp:351:7
- [modernize-use-scoped-lock] warning: use 'std::scoped_lock' instead of 'std::lock_guard' 
  - BasemapGalleryController.cpp:537
  - BasemapGalleryController.cpp:543
  - BasemapGalleryController.cpp:549 