### PR TITLE
Use function name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,4 @@ Plugin/CppApi/output/
 
 Makefile*
 
+uitools/examples/build

--- a/uitools/common/src/UtilityNetworkFunctionTraceResult.cpp
+++ b/uitools/common/src/UtilityNetworkFunctionTraceResult.cpp
@@ -17,6 +17,8 @@
 
 #include "UtilityNetworkFunctionTraceResult.h"
 
+#include <utility>
+
 namespace Esri::ArcGISRuntime::Toolkit
 {
 
@@ -25,19 +27,22 @@ namespace Esri::ArcGISRuntime::Toolkit
     This class is an internal implementation detail and is subject to change.
    */
 
-  UtilityNetworkFunctionTraceResult::UtilityNetworkFunctionTraceResult(const QString& name, UtilityTraceFunctionType type, double value) :
-    m_name(name),
+  UtilityNetworkFunctionTraceResult::UtilityNetworkFunctionTraceResult(QString functionName,
+                                                                       QString networkAttributeName,
+                                                                       UtilityTraceFunctionType type,
+                                                                       double value) :
+    m_functionName(std::move(functionName)),
+    m_networkAttributeName(std::move(networkAttributeName)),
     m_type(type),
     m_value(value)
   {
-    //
   }
 
   UtilityNetworkFunctionTraceResult::~UtilityNetworkFunctionTraceResult() = default;
 
   QString UtilityNetworkFunctionTraceResult::name() const
   {
-    return m_name;
+    return m_functionName.isEmpty() ? QStringLiteral("%1 (%2)").arg(m_networkAttributeName, typeAsLabel()) : m_functionName;
   }
 
   UtilityTraceFunctionType UtilityNetworkFunctionTraceResult::type() const

--- a/uitools/common/src/UtilityNetworkFunctionTraceResult.h
+++ b/uitools/common/src/UtilityNetworkFunctionTraceResult.h
@@ -23,9 +23,6 @@
 // STL headers
 #include <UtilityNetworkTypes.h>
 
-// Other headers
-#include "GenericListModel.h"
-
 namespace Esri::ArcGISRuntime::Toolkit
 {
 
@@ -33,7 +30,7 @@ namespace Esri::ArcGISRuntime::Toolkit
   {
   public:
     explicit UtilityNetworkFunctionTraceResult();
-    UtilityNetworkFunctionTraceResult(const QString& name, const UtilityTraceFunctionType type, double value);
+    UtilityNetworkFunctionTraceResult(QString functionName, QString networkAttributeName, UtilityTraceFunctionType type, double value);
     ~UtilityNetworkFunctionTraceResult();
 
     QString name() const;
@@ -42,7 +39,8 @@ namespace Esri::ArcGISRuntime::Toolkit
     double value() const;
 
   private:
-    QString m_name;
+    QString m_functionName;
+    QString m_networkAttributeName;
     UtilityTraceFunctionType m_type;
     double m_value;
   };

--- a/uitools/common/src/UtilityNetworkFunctionTraceResult.h
+++ b/uitools/common/src/UtilityNetworkFunctionTraceResult.h
@@ -29,7 +29,6 @@ namespace Esri::ArcGISRuntime::Toolkit
   class UtilityNetworkFunctionTraceResult
   {
   public:
-    explicit UtilityNetworkFunctionTraceResult();
     UtilityNetworkFunctionTraceResult(QString functionName, QString networkAttributeName, UtilityTraceFunctionType type, double value);
     ~UtilityNetworkFunctionTraceResult();
 
@@ -37,6 +36,8 @@ namespace Esri::ArcGISRuntime::Toolkit
     UtilityTraceFunctionType type() const;
     QString typeAsLabel() const;
     double value() const;
+
+    UtilityNetworkFunctionTraceResult() = delete;
 
   private:
     QString m_functionName;

--- a/uitools/common/src/UtilityNetworkTraceController.cpp
+++ b/uitools/common/src/UtilityNetworkTraceController.cpp
@@ -761,8 +761,9 @@ namespace Esri::ArcGISRuntime::Toolkit
 
           for (const auto o : outputList)
           {
-            m_functionResults->addFunctionResult(
-              UtilityNetworkFunctionTraceResult(o->function()->networkAttribute()->name(), o->function()->functionType(), o->result().toDouble()));
+            const auto function = o->function();
+            m_functionResults->addFunctionResult(UtilityNetworkFunctionTraceResult(function->functionName(), function->networkAttribute()->name(),
+                                                                                   function->functionType(), o->result().toDouble()));
           }
 
           break;

--- a/uitools/common/src/UtilityNetworkTraceController.cpp
+++ b/uitools/common/src/UtilityNetworkTraceController.cpp
@@ -62,7 +62,6 @@
 #include <UtilityNetworkListModel.h>
 #include <UtilityNetworkSource.h>
 #include <UtilityNetworkTypes.h>
-#include <UtilityTerminal.h>
 #include <UtilityTerminalConfiguration.h>
 #include <UtilityTraceFunction.h>
 #include <UtilityTraceFunctionOutput.h>
@@ -551,7 +550,9 @@ namespace Esri::ArcGISRuntime::Toolkit
 
   void UtilityNetworkTraceController::refresh()
   {
+    delete m_selectedUtilityNetwork;
     m_selectedUtilityNetwork = nullptr;
+    delete m_selectedTraceConfiguration;
     m_selectedTraceConfiguration = nullptr;
     m_traceConfigurations.clear();
     m_startingPoints->clear();
@@ -577,18 +578,7 @@ namespace Esri::ArcGISRuntime::Toolkit
     setupUtilityNetworks();
   }
 
-  void UtilityNetworkTraceController::addStartingPoint(QObject* identifiedFeatureObject, const QString& terminalName)
-  {
-    auto* identifiedFeature = qobject_cast<ArcGISFeature*>(identifiedFeatureObject);
-    if (!identifiedFeature)
-    {
-      return;
-    }
-
-    addStartingPoint(identifiedFeature, identifiedFeature->geometry().extent().center(), terminalName);
-  }
-
-  void UtilityNetworkTraceController::addStartingPoint(ArcGISFeature* identifiedFeature, const Point& mapPoint, const QString& terminalName)
+  void UtilityNetworkTraceController::addStartingPoint(ArcGISFeature* identifiedFeature, const Point& mapPoint)
   {
     auto geometry = identifiedFeature->geometry();
 
@@ -640,16 +630,8 @@ namespace Esri::ArcGISRuntime::Toolkit
         QList<UtilityTerminal*> terminals = utilityTerminalConfiguration->terminals();
         if (terminals.size() > 1)
         {
-          auto* selectedTerminal = terminals.first();
-          for (auto* terminal : terminals)
-          {
-            if (terminal->name() == terminalName || terminalName.endsWith(QStringLiteral(":%1").arg(terminal->name())))
-            {
-              selectedTerminal = terminal;
-              break;
-            }
-          }
-          utilityElement->setTerminal(selectedTerminal);
+          // The user can select between multiple terminals, but by default the first one is selected
+          utilityElement->setTerminal(utilityElement->assetType()->terminalConfiguration()->terminals().at(0));
         }
       }
 
@@ -779,9 +761,8 @@ namespace Esri::ArcGISRuntime::Toolkit
 
           for (const auto o : outputList)
           {
-            const auto function = o->function();
-            m_functionResults->addFunctionResult(UtilityNetworkFunctionTraceResult(function->functionName(), function->networkAttribute()->name(),
-                                                                                   function->functionType(), o->result().toDouble()));
+            m_functionResults->addFunctionResult(
+              UtilityNetworkFunctionTraceResult(o->function()->networkAttribute()->name(), o->function()->functionType(), o->result().toDouble()));
           }
 
           break;
@@ -961,19 +942,7 @@ namespace Esri::ArcGISRuntime::Toolkit
 
   void UtilityNetworkTraceController::handleArcGISAuthenticationChallenge(ArcGISAuthenticationChallenge* challenge)
   {
-    const bool isFallback = challenge->requestUrl().host() == QStringLiteral("sampleserver7.arcgisonline.com");
-    const char* usernameVariable = isFallback ? "UTILITY_NETWORK_TRACE_FALLBACK_USERNAME" : "UTILITY_NETWORK_TRACE_NAMED_USERNAME";
-    const char* passwordVariable = isFallback ? "UTILITY_NETWORK_TRACE_FALLBACK_PASSWORD" : "UTILITY_NETWORK_TRACE_NAMED_PASSWORD";
-    const QString username = qEnvironmentVariable(usernameVariable);
-    const QString password = qEnvironmentVariable(passwordVariable);
-    if (username.isEmpty() || password.isEmpty())
-    {
-      qWarning() << "Set" << usernameVariable << "and" << passwordVariable << "to run this trace test.";
-      challenge->cancel();
-      return;
-    }
-
-    TokenCredential::createWithChallengeAsync(challenge, username, password, {}, this)
+    TokenCredential::createWithChallengeAsync(challenge, "viewer01", "I68VGU^nMurF", {}, this)
       .then(this,
             [challenge](TokenCredential* tokenCredential)
     {

--- a/uitools/common/src/UtilityNetworkTraceController.cpp
+++ b/uitools/common/src/UtilityNetworkTraceController.cpp
@@ -62,6 +62,7 @@
 #include <UtilityNetworkListModel.h>
 #include <UtilityNetworkSource.h>
 #include <UtilityNetworkTypes.h>
+#include <UtilityTerminal.h>
 #include <UtilityTerminalConfiguration.h>
 #include <UtilityTraceFunction.h>
 #include <UtilityTraceFunctionOutput.h>
@@ -550,9 +551,7 @@ namespace Esri::ArcGISRuntime::Toolkit
 
   void UtilityNetworkTraceController::refresh()
   {
-    delete m_selectedUtilityNetwork;
     m_selectedUtilityNetwork = nullptr;
-    delete m_selectedTraceConfiguration;
     m_selectedTraceConfiguration = nullptr;
     m_traceConfigurations.clear();
     m_startingPoints->clear();
@@ -578,7 +577,18 @@ namespace Esri::ArcGISRuntime::Toolkit
     setupUtilityNetworks();
   }
 
-  void UtilityNetworkTraceController::addStartingPoint(ArcGISFeature* identifiedFeature, const Point& mapPoint)
+  void UtilityNetworkTraceController::addStartingPoint(QObject* identifiedFeatureObject, const QString& terminalName)
+  {
+    auto* identifiedFeature = qobject_cast<ArcGISFeature*>(identifiedFeatureObject);
+    if (!identifiedFeature)
+    {
+      return;
+    }
+
+    addStartingPoint(identifiedFeature, identifiedFeature->geometry().extent().center(), terminalName);
+  }
+
+  void UtilityNetworkTraceController::addStartingPoint(ArcGISFeature* identifiedFeature, const Point& mapPoint, const QString& terminalName)
   {
     auto geometry = identifiedFeature->geometry();
 
@@ -630,8 +640,16 @@ namespace Esri::ArcGISRuntime::Toolkit
         QList<UtilityTerminal*> terminals = utilityTerminalConfiguration->terminals();
         if (terminals.size() > 1)
         {
-          // The user can select between multiple terminals, but by default the first one is selected
-          utilityElement->setTerminal(utilityElement->assetType()->terminalConfiguration()->terminals().at(0));
+          auto* selectedTerminal = terminals.first();
+          for (auto* terminal : terminals)
+          {
+            if (terminal->name() == terminalName || terminalName.endsWith(QStringLiteral(":%1").arg(terminal->name())))
+            {
+              selectedTerminal = terminal;
+              break;
+            }
+          }
+          utilityElement->setTerminal(selectedTerminal);
         }
       }
 
@@ -761,8 +779,9 @@ namespace Esri::ArcGISRuntime::Toolkit
 
           for (const auto o : outputList)
           {
-            m_functionResults->addFunctionResult(
-              UtilityNetworkFunctionTraceResult(o->function()->networkAttribute()->name(), o->function()->functionType(), o->result().toDouble()));
+            const auto function = o->function();
+            m_functionResults->addFunctionResult(UtilityNetworkFunctionTraceResult(function->functionName(), function->networkAttribute()->name(),
+                                                                                   function->functionType(), o->result().toDouble()));
           }
 
           break;
@@ -942,7 +961,19 @@ namespace Esri::ArcGISRuntime::Toolkit
 
   void UtilityNetworkTraceController::handleArcGISAuthenticationChallenge(ArcGISAuthenticationChallenge* challenge)
   {
-    TokenCredential::createWithChallengeAsync(challenge, "viewer01", "I68VGU^nMurF", {}, this)
+    const bool isFallback = challenge->requestUrl().host() == QStringLiteral("sampleserver7.arcgisonline.com");
+    const char* usernameVariable = isFallback ? "UTILITY_NETWORK_TRACE_FALLBACK_USERNAME" : "UTILITY_NETWORK_TRACE_NAMED_USERNAME";
+    const char* passwordVariable = isFallback ? "UTILITY_NETWORK_TRACE_FALLBACK_PASSWORD" : "UTILITY_NETWORK_TRACE_NAMED_PASSWORD";
+    const QString username = qEnvironmentVariable(usernameVariable);
+    const QString password = qEnvironmentVariable(passwordVariable);
+    if (username.isEmpty() || password.isEmpty())
+    {
+      qWarning() << "Set" << usernameVariable << "and" << passwordVariable << "to run this trace test.";
+      challenge->cancel();
+      return;
+    }
+
+    TokenCredential::createWithChallengeAsync(challenge, username, password, {}, this)
       .then(this,
             [challenge](TokenCredential* tokenCredential)
     {

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/UtilityNetworkTrace.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/UtilityNetworkTrace.qml
@@ -310,12 +310,6 @@ Pane {
                                         text: name + ": " + value
                                         horizontalAlignment: Text.AlignLeft
                                     }
-                                    Label {
-                                        Layout.fillWidth: true
-                                        elide: Text.ElideRight
-                                        text: "Function type: <i>" + type + "</i>"
-                                        horizontalAlignment: Text.AlignLeft
-                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
This changes the tool to do the following:
 * Clean up a bit of code and use modern style.
 * Use the "Function name" if present, as specified by the feature team.

The test design expectations are as follows. Of note, the feature team's tool and design differ significantly from the Qt tool, so screenshots will differ.

## Configured **with** FunctionName

Feature team screenshot:
<img width="528" height="454" alt="Screenshot 2026-07-20 at 10 50 22 AM" src="https://github.com/user-attachments/assets/3ef5acbc-8801-4859-919d-b5fba7e57877" />

## Configured **without** FunctionName

Feature team screenshot:
<img width="505" height="638" alt="Screenshot 2026-07-20 at 10 50 27 AM" src="https://github.com/user-attachments/assets/3e289de9-b200-4c42-8695-96fb206c0850" />


And with these changes, we are now getting:

## Configured **with** FunctionName

<img width="798" height="634" alt="Screenshot 2026-07-20 at 10 23 07 AM" src="https://github.com/user-attachments/assets/74d94675-93e3-4d48-9d54-f6c6b26a32d0" />

## Configured **without** FunctionName

<img width="802" height="635" alt="Screenshot 2026-07-20 at 10 22 54 AM" src="https://github.com/user-attachments/assets/a42d2c53-d19b-4a02-8e9e-35388cbbade5" />

(and this, because there are supposed to be 2 "Device Asset Group" entries, and we do have both):
<img width="443" height="549" alt="Screenshot 2026-07-20 at 10 28 15 AM" src="https://github.com/user-attachments/assets/8525dc12-5cb9-4907-9ad1-68b5ff859266" />


The Qt "without" expectation doesn't match the feature team screenshot, but the test design says the text should read "Device Asset Group" (Count)", so these changes combine the text into a single line rather than putting "Count" on a second line.