### PR TITLE
Fix Scalebar units not changing.

### DIFF
--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/Scalebar.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/Scalebar.qml
@@ -102,7 +102,7 @@ Control {
             implicitHeight: scalebar.implicitHeight
             font: scalebar.font
             controller: scalebar.controller
-            unitSystem: unitSystem === unitSystem.Dual ? Scalebar.UnitSystem.Metric : unitSystem
+            unitSystem: scalebar.unitSystem === Scalebar.UnitSystem.Dual ? Scalebar.UnitSystem.Metric : scalebar.unitSystem
         }
     }
 

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/Scalebar.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/Scalebar.qml
@@ -113,6 +113,15 @@ Control {
         value: mapView
     }
 
+    Binding {
+        restoreMode: Binding.RestoreNone
+        target: controller
+        property: "unitSystem"
+        value: unitSystem === Scalebar.UnitSystem.Dual
+               ? Scalebar.UnitSystem.Metric
+               : unitSystem
+    }
+
     onMapViewChanged: {
         if (controller) {
             controller.mapView = mapView;

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/Scalebar.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/Scalebar.qml
@@ -117,9 +117,7 @@ Control {
         restoreMode: Binding.RestoreNone
         target: controller
         property: "unitSystem"
-        value: unitSystem === Scalebar.UnitSystem.Dual
-               ? Scalebar.UnitSystem.Metric
-               : unitSystem
+        value: unitSystem === Scalebar.UnitSystem.Dual ? Scalebar.UnitSystem.Metric : unitSystem
     }
 
     onMapViewChanged: {

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/ScalebarImpl.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/ScalebarImpl.qml
@@ -54,6 +54,12 @@ Control {
         }
     }
 
+    onUnitSystemChanged: {
+        if (controller && controller.mapView) {
+            internal.calculateScale();
+        }
+    }
+
     QtObject {
         id: internal
 

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/ScalebarImpl.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/ScalebarImpl.qml
@@ -54,12 +54,6 @@ Control {
         }
     }
 
-    onUnitSystemChanged: {
-        if (controller && controller.mapView) {
-            internal.calculateScale();
-        }
-    }
-
     QtObject {
         id: internal
 
@@ -82,6 +76,13 @@ Control {
         property Connections geoViewConnections: Connections {
             target: controller.mapView
             function onViewpointChanged() {
+                internal.calculateScale();
+            }
+        }
+
+        property Connections controllerConnections: Connections {
+            target: controller
+            function onUnitSystemChanged() {
                 internal.calculateScale();
             }
         }

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/ScalebarImpl.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/ScalebarImpl.qml
@@ -70,7 +70,7 @@ Control {
             // Calculate the new displayed scalebar width.
             internal.displayWidth = controller.calculateDisplayWidth(displayDistance, maxDistance, availableWidth);
             // Display the value of the calculated distance.
-            internal.displayDistance = controller.calculateDistanceInDisplayUnits(displayDistance, scalebar.unitSystem);
+            internal.displayDistance = controller.calculateDistanceInDisplayUnits(displayDistance, controller.unitSystem);
         }
 
         property Connections geoViewConnections: Connections {

--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/ScalebarImpl.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/ScalebarImpl.qml
@@ -70,7 +70,7 @@ Control {
             // Calculate the new displayed scalebar width.
             internal.displayWidth = controller.calculateDisplayWidth(displayDistance, maxDistance, availableWidth);
             // Display the value of the calculated distance.
-            internal.displayDistance = controller.calculateDistanceInDisplayUnits(displayDistance, controller.unitSystem);
+            internal.displayDistance = controller.calculateDistanceInDisplayUnits(displayDistance, scalebar.unitSystem);
         }
 
         property Connections geoViewConnections: Connections {


### PR DESCRIPTION
`unitSystem: Scalebar.UnitSystem.Imperial` does not change units to imperial. This PR fixes that.