### PR TITLE
Do not explicitly set title if empty

### DIFF
--- a/uitools/common/src/FieldsPopupElementViewController.cpp
+++ b/uitools/common/src/FieldsPopupElementViewController.cpp
@@ -45,7 +45,7 @@ namespace Esri::ArcGISRuntime::Toolkit
   QString FieldsPopupElementViewController::title() const
   {
     const auto title = static_cast<FieldsPopupElement*>(popupElement())->title();
-    return !title.isEmpty() ? title : QStringLiteral("Fields");
+    return title.trimmed().isEmpty() ? QString{} : title;
   }
 
   QVariantList FieldsPopupElementViewController::labelsAndValues() const


### PR DESCRIPTION
Avoid explicitly setting the title when it is empty or contains only whitespace