### PR TITLE
Fix bookmark selection on click

### DIFF
--- a/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/BookmarksView.qml
+++ b/uitools/toolkitcpp/import/Esri/ArcGISRuntime/Toolkit/BookmarksView.qml
@@ -74,7 +74,7 @@ Pane {
             text: name
             width: listView.width
             indicator: null
-            onPressed: controller.zoomToBookmarkExtent(listModelData)
+            onClicked: controller.zoomToBookmarkExtent(listModelData)
         }
     }
 


### PR DESCRIPTION
Use `onClicked` instead of `onPressed` to prevent bookmark selection while navigating the list.